### PR TITLE
fix(ci): pin ruff to the lockfile version and bump the stale shard-count pin (CHAOS-3946)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install ruff==0.15.12
           pip install -r requirements.txt
 
       # Before the two steps whose exit status IS the `lint` gate: prove ruff

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -243,8 +243,8 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
 
     expected_provider_tests = _providersync_top_level_tests()
     expected_integration_tests = _providersync_integration_tagged_tests()
-    assert len(expected_provider_tests) == 921
-    assert len(expected_integration_tests) == 107
+    assert len(expected_provider_tests) == 934
+    assert len(expected_integration_tests) == 108
     assert expected_integration_tests < expected_provider_tests
 
     provider_assignments: dict[int, set[str]] = {}
@@ -260,7 +260,7 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
     provider_flattened = [
         test_name for tests in provider_assignments.values() for test_name in tests
     ]
-    assert len(provider_flattened) == len(set(provider_flattened)) == 921
+    assert len(provider_flattened) == len(set(provider_flattened)) == 934
     assert set(provider_flattened) == expected_provider_tests
     assert {
         name
@@ -321,7 +321,7 @@ def test_each_shard_dry_run_executes_only_its_manifest_assignment() -> None:
         )
 
     expected_tests = _providersync_top_level_tests()
-    assert len(selected_tests) == len(set(selected_tests)) == 921
+    assert len(selected_tests) == len(set(selected_tests)) == 934
     assert set(selected_tests) == expected_tests
 
 


### PR DESCRIPTION
## Summary

Main is red two ways any Python-touching PR discovers: unpinned `ruff` in CI, and a stale shard-plan test-count pin. Both are the same class of hole — a value that drifts silently because the check that would catch it is path-filtered away from the Go-only PRs that merge most often — so this PR fixes both instances together to make it self-contained (see below for why: fixing only the ruff pin here hit the shard-pin failure through the same `test.yml` matrix, and fixing only the shard pin on `main`'s side needs the ruff pin to get a clean lint-job — chicken-and-egg otherwise).

## 1. `lint.yml`'s `ruff` install was unpinned

`lint.yml`'s Install dependencies step ran a bare `pip install ruff`, resolving to whatever is newest on PyPI at CI run time (0.16.3) instead of the version the project's own lockfile pins for contributors (0.15.12, `uv.lock`). The two versions disagree on formatting for parts of the tree, so `ruff format --check .` — a full-repo check, not diff-scoped — fails in CI on files a contributor running `uv sync` + `ruff format --check` locally sees as already formatted. Pinning `ruff==0.15.12` needs no file reformatting: the lockfile version is what already agrees with the tree.

## 2. `tests/tooling/test_go_integration_sharding.py`'s providersync test-count pin was stale

That test pins the live-discovered count of `internal/providersync` top-level tests (was 921) and integration-tagged tests (was 107) as a sentinel that forces a human to notice and re-examine `ci/go_providersync_test_shards.tsv`'s hand-tuned relative weights whenever the package's test surface grows. Five commits merged into main since 08-18 added providersync tests without bumping it: `15e02aa7e` (+3), `84fe7690d` (+3), `d360676a7` (+3), `803041649` (+1), `206d60a49` (+3) — 13 tests, 921 → 934. Regenerated by rerunning `bash ci/check_go.sh integration-shard-plan` against current `origin/main` and transcribing its live counts — the same method used when this pin was first introduced in #1738. There is no separate generator script for these two literals, and the package-level manifest (`ci/go_integration_shards.tsv`) needs no change (package set unchanged at 26, self-validated against live discovery on every run).

## Why both were invisible on main

- `go.yml`'s push trigger has been commented out since `f5e5ee4ff` for Actions concurrency budget, and it isn't a required check.
- `test.yml`'s path filters are Go-blind — a Go-only commit never runs the Python suite that would catch the shard-count drift.
- `lint.yml`'s `lint-job` is itself path-filtered (the `changes` job), so a PR that never touches a Python file never triggers the unpinned-ruff drift either.

Nothing forces either into view until a PR crosses both filters at once — which is exactly what happened when PR #1813 (a Go PR that also touches a Python test file and deploy/docs paths) rebased through main and inherited both.

## Test plan
- [x] `uv run pytest tests/tooling/test_go_integration_sharding.py -q` → 8 passed
- [x] `uv run ruff --version` locally → 0.15.12, matches the pin
- [ ] CI green: `lint-job` with no file reformatting, `test`/`test-matrix (3.14)` passing on the bumped pin
