### PR TITLE
fix(ci): give Go changes real CI coverage on required checks and main (CHAOS-3948)

### DIFF
--- a/.github/workflows/docs-inventory-review.yml
+++ b/.github/workflows/docs-inventory-review.yml
@@ -33,7 +33,11 @@ jobs:
           python-version: '3.14'
 
       - name: Install inventory dependency
-        run: python -m pip install 'PyYAML>=6.0.3'
+        # CHAOS-3948: pinned to the uv.lock version, same shape/fix as
+        # lint.yml's ruff pin (CHAOS-3946) -- a bare floor specifier resolves
+        # to whatever is newest on PyPI at CI run time, not the version
+        # contributors actually run locally via `uv sync`.
+        run: python -m pip install 'PyYAML==6.0.3'
 
       - name: Validate the frozen Phase 1 inventory and dispositions
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -77,6 +77,17 @@ on:
       - '.github/workflows/go.yml'
   merge_group:
   workflow_dispatch:
+  # CHAOS-3948: push (above) stays off deliberately -- see the concurrency
+  # block below -- so main got zero Go CI between merges: go.yml only ran on
+  # the PR that introduced a change and on the merge_group queue run, never
+  # again afterward. A scheduled run against main's HEAD (`schedule` always
+  # targets the default branch) closes most of that gap at a fixed cost of
+  # one fan-out a day, which cannot amplify into a merge burst the way `push`
+  # did -- it does not touch the mechanism that exhausted the org's Actions
+  # concurrency. `workflow_dispatch` above also gives a one-click way to run
+  # the full matrix against main on demand between nightly runs.
+  schedule:
+    - cron: '17 8 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/scheduled-scan.yml
+++ b/.github/workflows/scheduled-scan.yml
@@ -22,7 +22,11 @@ jobs:
           python-version: "3.14"
 
       - name: Install pip-audit
-        run: pip install "pip-audit>=2.7.0"
+        # CHAOS-3948: pinned to the uv.lock version, same shape/fix as
+        # lint.yml's ruff pin (CHAOS-3946) -- a bare floor specifier resolves
+        # to whatever is newest on PyPI at CI run time, not the version
+        # contributors actually run locally via `uv sync`.
+        run: pip install "pip-audit==2.10.0"
 
       - name: Run pip-audit
         run: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -31,7 +31,11 @@ jobs:
           cache: "pip"
 
       - name: Install pip-audit
-        run: pip install "pip-audit>=2.7.0"
+        # CHAOS-3948: pinned to the uv.lock version, same shape/fix as
+        # lint.yml's ruff pin (CHAOS-3946) -- a bare floor specifier resolves
+        # to whatever is newest on PyPI at CI run time, not the version
+        # contributors actually run locally via `uv sync`.
+        run: pip install "pip-audit==2.10.0"
 
       - name: Run pip-audit (fail on any vulnerability)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,29 @@ jobs:
               # test job and the gate went green (CHAOS-3482 Codex round 4).
               - 'docker/**'
               - 'deploy/**'
+              # CHAOS-3948: this filter had no Go paths at all, so a Go-only
+              # PR (internal/**, cmd/**, *.go, go.mod, go.sum -- 722 + 57
+              # files) reported code=false, skipped test-matrix/coverage
+              # entirely, and the required `test` check went green having run
+              # nothing. That is not a harmless skip: tests/tooling/*.py
+              # (already selected by 'tests/**' above, but only when a PR ALSO
+              # touches a Python file) polices Go artifacts directly --
+              # test_go_integration_sharding.py asserts the live Go package
+              # inventory against ci/go_integration_shards.tsv,
+              # test_go_image_publishing.py asserts published image names
+              # against deploy/ renderers, test_go_worker_stop_hook_packaging.py
+              # asserts the Dockerfile's staged binary path -- and a Go-only
+              # PR is exactly the PR that can break what those tests check
+              # while never running them. contracts/** and go.mod/go.sum are
+              # not covered by any existing pattern above (they sit outside
+              # src/, tests/, ci/, docker/, deploy/), so they are listed
+              # explicitly.
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'internal/**'
+              - 'cmd/**'
+              - 'contracts/**'
 
   # Fast, pytest-xdist-parallelized unit suite on the supported Python
   # version. This is the per-PR signal that the required `test` gate (below)

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -264,7 +264,7 @@ LATEST_WORK_UNIT_AUTHORS_CTE = """
 # false TEAM:unassigned Sankey node even though attribution already existed.
 # This is the single source every Investment Sankey/coverage team join must
 # read from: work_item_team_attributions FINAL, is_primary = 1, latest by
-# computed_at per work_item_id (docs/architecture/team-attribution.md §0).
+# computed_at per work_item_id (docs/contribute/architecture/team-attribution.md §0).
 # Filter to the latest snapshot before reading plain nullable team fields so a
 # newer primary row with NULL team fields clears an older assigned team.
 # Centralized so no caller drifts back onto work_item_cycle_times.

--- a/src/dev_health_ops/external_ingest/sinks.py
+++ b/src/dev_health_ops/external_ingest/sinks.py
@@ -511,8 +511,9 @@ def _build_work_item_row(
         "status_raw": get("status_raw"),
         "project_key": project_key,
         "project_id": project_id,
-        # Team-attribution precedence (docs/architecture/team-attribution.md
-        # §0, AGENTS.md) treats any non-empty work_items.native_team_key as a
+        # Team-attribution precedence
+        # (docs/contribute/architecture/team-attribution.md §0, AGENTS.md)
+        # treats any non-empty work_items.native_team_key as a
         # top-precedence NATIVE fact -- native sync only ever populates it
         # for Linear (WorkItem.native_team_key docstring: "None for
         # GitHub/GitLab ... and Jira"). `system` is now always

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -132,7 +132,7 @@ class TeamAttributionContext:
 # CHAOS-2600: deterministic staged precedence. linked_issue is a TRUE FALLBACK
 # (rank 5) below every native/imported fact — it never overrides ownership or
 # assignee membership; it only beats manual_fallback and unassigned. native_team
-# stays top. See docs/architecture/team-attribution.md §0.
+# stays top. See docs/contribute/architecture/team-attribution.md §0.
 _SOURCE_ORDER: dict[TeamAttributionSource, int] = {
     "native_team": 0,
     "issue_project": 1,
@@ -151,7 +151,7 @@ _SOURCE_ORDER: dict[TeamAttributionSource, int] = {
 # can never be laundered into rank-5 `linked_issue` provenance on a dependent
 # item. linked_issue itself is absent here because donor resolution runs with
 # `linked_issue_resolver=None` (no transitive inheritance). See
-# docs/architecture/team-attribution.md §0.
+# docs/contribute/architecture/team-attribution.md §0.
 _DONOR_SOURCES: frozenset[TeamAttributionSource] = frozenset(
     {
         "native_team",


### PR DESCRIPTION
## Summary

Closes the CI gate holes documented in CHAOS-3948's 5th comment: Go-only PRs were passing the repo's only two required checks (`test`, `lint`) in ~7s having run nothing, and `go.yml` has run zero Go CI on main since 2026-08-03. Two small unrelated repairs ride along.

- **Widened `test.yml`'s `code` path filter** with `**/*.go`, `go.mod`, `go.sum`, `internal/**`, `cmd/**`, `contracts/**`. `internal/` has 722 Go files, `cmd/` has 57; none were in the filter, so a Go-only PR reported `code=false` and skipped `test-matrix`/`coverage` — which is where `tests/tooling/test_go_integration_sharding.py`, `test_go_image_publishing.py`, `test_go_worker_stop_hook_packaging.py` etc. live, the Python suite that polices Go artifacts (live package inventory, published image names, Dockerfile staging paths). 14 of the last 28 commits to main were Go-only. This is exactly how a stale test-count pin sat red-in-hiding on main until an unrelated Python-touching PR crossed the filter and tripped it (fixed today in #1816).
  - **`lint.yml`/`typecheck.yml` deliberately left untouched.** ruff/mypy are Python-only full-repo scans (`ruff check .`, `mypy .`) with no narrower job to select; a Go-only diff changes zero files either tool inspects, so widening them adds CI cost with no new signal — the opposite of what this PR is fixing. Verified against `tests/tooling/test_aggregate_gate_results.py::test_filter_selects_on_the_inputs_that_define_tool_scope`, which only asserts tool-config-file coverage, nothing Go-related.
- **Added `schedule: cron: '17 8 * * *'` to `go.yml`** (kept the existing `workflow_dispatch`). `go.yml`'s `push`-to-main trigger has been commented out since `f5e5ee4ff` (2026-08-03) and stays off deliberately: `c802db047` (2026-08-18) restored `pull_request` after three real breakages reached a long-lived branch undetected, but found `push` is the one trigger that is both non-cancellable and fires per-commit — a burst of merges holding several full ~13-job fan-outs concurrently is what previously exhausted the org's GitHub Actions concurrency. That's a ratified, evidence-backed decision (independently reconfirmed by today's `fe620eb41` commit message), not an oversight, and reversing it needs concurrency-headroom data this PR doesn't have. The nightly `schedule` (schedule always targets the default branch) plus on-demand `workflow_dispatch` gets Go tests running against main's HEAD again at a fixed one-fan-out-per-day cost that can't amplify into the merge-burst shape that caused the incident. Verified no job-level `if` in `go.yml` gates on `pull_request`/`merge_group`; the one step that does (base-contract-diff prep) degrades to validating the additive tree rather than skipping the gate — same as it already did for `push` before it was disabled.
- **Pinned two more unpinned tool installs** to their `uv.lock` versions, same shape as `lint.yml`'s ruff pin (#1816, CHAOS-3946): `docs-inventory-review.yml`'s `PyYAML>=6.0.3` → `==6.0.3`, and `security-scan.yml`/`scheduled-scan.yml`'s `pip-audit>=2.7.0` → `==2.10.0`. Checked `semgrep>=1.99.0`, `pip install build`, `pip install uv` too — none are declared in `pyproject.toml`/`uv.lock` at all, so there's no lockfile version to pin to; left them intentionally unpinned.
- **Fixed 4 dead doc references** (comment-only): `docs/architecture/team-attribution.md` → `docs/contribute/architecture/team-attribution.md` in `compute_work_items.py` (x2), `investment.py`, `sinks.py`. The §0 anchor they cite still matches line 66 of the restored page.

## Two owner decisions this PR does not make

1. **Promote `go` to a required status check.** Only `test` and `lint` are required today (branch ruleset 5324160); `go.yml` gates nothing at merge time beyond `merge_group`. This is a repo-settings/ruleset change, out of scope for a code PR.
2. **Re-enable `go.yml`'s `push` trigger.** Mechanically trivial; the actual blocker is confirming the org's Actions concurrency budget has headroom now. The nightly schedule added here narrows the gap without touching that decision.

## Test Evidence

TEST-EVIDENCE:
- `pytest tests/tooling/test_go_integration_sharding.py -q` → 8 passed
- `pytest tests/tooling/test_go_worker_stop_hook_packaging.py tests/tooling/test_check_go_integration_coverage.py tests/tooling/test_check_go_public_verbs.py tests/tooling/test_go_image_publishing.py tests/tooling/test_aggregate_gate_results.py -q` → 145 passed
- `ruff format --check` / `ruff check` on the 3 edited Python files → clean (also re-verified by the pre-commit/pre-push lefthook mypy+ruff run)
- All 5 edited workflow YAML files parse with `yaml.safe_load`
- This diff touches workflows, so it triggers the full required matrix rather than a path-filtered skip.

## Risk Notes

RISK-NOTES: Blast radius is CI configuration only, no runtime/prod code paths. Rollback is reverting the 3 commits. The `go.yml` schedule addition is new recurring cost (~1 fan-out/day, ~13 jobs, some at a 25-min cap) but is bounded and non-cancellable-burst-safe by construction. Monitoring: watch the nightly run once it fires, and the `workflow_dispatch` gives a way to verify manually before then. Follow-ups: CHAOS-3948 comment thread has the full evidence trail; the two owner decisions above are the explicit follow-ups.

## Optional Context

- Linked issues: CHAOS-3948
- Additional notes: none