### PR TITLE
fix(syncreconciler): reclaim exhausted coordinator deliveries instead of wedging the run (CHAOS-3951)

### DIFF
--- a/alerts/rules.yml
+++ b/alerts/rules.yml
@@ -204,9 +204,20 @@ groups:
       # a single looping run is a rounding error against fleet attempt volume
       # -- which is exactly why the original wedge went unnoticed.
       #
-      # One looping run reclaims every few minutes, so it clears this
-      # threshold on its own; a handful of unrelated runs each recovering once
-      # from the same outage does not.
+      # Window sizing. One looping run reclaims every few minutes, so it
+      # clears this threshold on its own; a handful of unrelated runs each
+      # recovering once from the same outage does not.
+      #
+      # The case NO count threshold can separate is a fleet-wide outage
+      # recovery: many DISTINCT runs each reclaim once, at the same moment.
+      # Telling that apart from one run reclaiming many times would need a
+      # per-run label, and a run label is an organization identifier, which the
+      # PRD forbids on a metric. So the only lever left is how long a one-off
+      # spike keeps paging -- and a rolling window keeps an instantaneous spike
+      # above the line for the width of the window. 2h was chosen over a longer
+      # window for exactly that reason: a mass recovery pages for two hours
+      # instead of six, while a single looping run still clears the threshold
+      # comfortably (~7-8 reclaims per 2h at River's ~16-minute attempt span).
       - alert: SyncDispatchExhaustedDeliveryRecoveryLoop
         expr: |
           sum(increase(sync_dispatch_exhausted_delivery_recoveries_total[2h])) > 3

--- a/alerts/rules.yml
+++ b/alerts/rules.yml
@@ -189,6 +189,39 @@ groups:
             More than 10% of attempts for {{ $labels.kind }} are retrying,
             discarded, or canceled.
 
+      # CHAOS-3951. River bounds the sync-dispatch coordinator kinds at five
+      # attempts and nothing below them carries a second retry budget, so an
+      # exhausted delivery is reclaimed by the reconciler rather than left to
+      # wedge its SyncRun forever. One reclaim is that recovery working: a
+      # web-API outage outlived the attempt span and the run resumes.
+      #
+      # A sustained repeat is not. It means the same delivery is failing
+      # deterministically -- a bad bridge credential, a payload-shape bug --
+      # and the reclaim is cycling instead of healing. That is the wedge's
+      # replacement failure mode, and it is silent by construction: the
+      # reclaimed row returns to 'pending' and is indistinguishable from a
+      # healthy one. GoWorkerAttemptFailureRateHigh does not cover it, because
+      # a single looping run is a rounding error against fleet attempt volume
+      # -- which is exactly why the original wedge went unnoticed.
+      #
+      # One looping run reclaims every few minutes, so it clears this
+      # threshold on its own; a handful of unrelated runs each recovering once
+      # from the same outage does not.
+      - alert: SyncDispatchExhaustedDeliveryRecoveryLoop
+        expr: |
+          sum(increase(sync_dispatch_exhausted_delivery_recoveries_total[2h])) > 3
+        for: 15m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "Sync-dispatch coordinator delivery is looping on exhaustion"
+          description: |
+            {{ $value | printf "%.0f" }} coordinator deliveries were reclaimed
+            after exhausting River's attempt budget in the last two hours. A
+            repeating reclaim means the compatibility bridge is failing
+            deterministically for a run, not recovering from an outage.
+
       - alert: GoWorkerDomainStateMismatch
         expr: |
           sum by (domain_type) (increase(worker_domain_state_mismatch_total[5m])) > 0

--- a/internal/syncreconciler/kernel_integration_test.go
+++ b/internal/syncreconciler/kernel_integration_test.go
@@ -765,18 +765,40 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 			WHERE id::text = $1`, secondJobID, now.Add(5*time.Second)); err != nil {
 			t.Fatal(err)
 		}
+		// CHAOS-3951 reverses this case deliberately. It used to assert that a
+		// delivery at attempt = max_attempts stays excluded, on the rationale
+		// that domain retry budgets remain authoritative. For the coordinator
+		// kinds there is no domain budget -- River's MaxAttempts is the only
+		// one -- so excluding them deferred to nothing and left the SyncRun
+		// non-terminal forever. Exhaustion is now recoverable regardless of
+		// what the last error said, under its own evidence code.
+		//
+		// The genuine permanent-failure guard is the assertion above, which
+		// still holds: a discard at attempt 1 with an ordinary worker error is
+		// not reclaimed. That is the case where a budget really does remain.
 		exhausted, err := repair.Step(ctx, now.Add(6*time.Second), 10)
-		if err != nil || exhausted.Recovered != 0 {
-			t.Fatalf("exhausted rescue repair Step() = %#v, %v", exhausted, err)
+		if err != nil || exhausted.Recovered != 1 || exhausted.ExhaustedRecovered != 1 {
+			t.Fatalf("exhausted repair Step() = %#v, %v", exhausted, err)
 		}
+		var recoveredError string
+		var clearedJobID *string
 		if err := adminPool.QueryRow(ctx, `
-			SELECT status, transport_job_id FROM public.sync_dispatch_outbox WHERE id = $1`,
+			SELECT status, transport_job_id, last_error
+			FROM public.sync_dispatch_outbox WHERE id = $1`,
 			integrationDispatchID,
-		).Scan(&status, &secondJobID); err != nil {
+		).Scan(&status, &clearedJobID, &recoveredError); err != nil {
 			t.Fatal(err)
 		}
-		if status != "dispatched" {
-			t.Fatalf("real terminal failure reopened: status=%s job=%s", status, secondJobID)
+		if status != "pending" || recoveredError != riverDeliveryExhaustedEvidence {
+			t.Fatalf(
+				"exhausted delivery not reclaimed under its own evidence: status=%s last_error=%s",
+				status, recoveredError,
+			)
+		}
+		// The retired delivery must be unlinked, or the next repair pass would
+		// see the same discarded job still attached to a live row.
+		if clearedJobID != nil {
+			t.Fatalf("reclaimed row still points at the retired delivery %s", *clearedJobID)
 		}
 	})
 
@@ -843,6 +865,7 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 		explainQuery = strings.ReplaceAll(explainQuery, "$2", "10")
 		explainQuery = strings.ReplaceAll(explainQuery, "$3", "'Stuck job rescued by JobRescuer'::text")
 		explainQuery = strings.ReplaceAll(explainQuery, "$4", "'river_unhandled_rescue'::text")
+		explainQuery = strings.ReplaceAll(explainQuery, "$5", "'river_delivery_exhausted'::text")
 		rows, err := tx.Query(ctx, "EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) "+explainQuery)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/syncreconciler/loop.go
+++ b/internal/syncreconciler/loop.go
@@ -251,6 +251,14 @@ func (loop *Loop) step(ctx context.Context, now time.Time) error {
 	stepCtx, cancel := context.WithTimeout(ctx, loop.config.ObservationTimeout)
 	defer cancel()
 	observation, err := loop.stepper.Step(stepCtx, now, loop.config.Limit)
+	// Recoveries are committed by the repair stage before anything downstream
+	// can fail, so they are counted here -- ahead of every error, timeout, and
+	// shutdown branch below. Counting them only on the success path would drop
+	// exactly the reclaims that happened during a degraded step, which is when
+	// a cycling delivery is most likely to be what is degrading it.
+	loop.mu.Lock()
+	loop.accumulateRecoveriesLocked(observation)
+	loop.mu.Unlock()
 	if contextErr := stepCtx.Err(); contextErr != nil {
 		return contextErr
 	}
@@ -285,7 +293,6 @@ func (loop *Loop) step(ctx context.Context, now time.Time) error {
 		return err
 	}
 	loop.observation = copyObservation(observation)
-	loop.accumulateRecoveriesLocked(observation)
 	loop.lastOK = now
 	loop.up = true
 	loop.ready.Store(true)

--- a/internal/syncreconciler/loop.go
+++ b/internal/syncreconciler/loop.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -112,11 +113,17 @@ type Loop struct {
 	done     chan struct{}
 	ticker   loopTicker
 
-	observation  Observation
-	lastOK       time.Time
-	up           bool
-	errors       chan error
-	recorderBusy chan struct{}
+	observation Observation
+	// exhaustedRecoveries accumulates across steps. Every other quantity here
+	// is a snapshot of current queued work, where a counter would misreport
+	// state after rows dispatch; a recovery is an event that already happened,
+	// so a snapshot is what would misreport it -- the next step's zero would
+	// erase the only evidence that a delivery had to be reclaimed at all.
+	exhaustedRecoveries uint64
+	lastOK              time.Time
+	up                  bool
+	errors              chan error
+	recorderBusy        chan struct{}
 }
 
 func NewLoop(stepper Stepper, config LoopConfig) (*Loop, error) {
@@ -278,12 +285,27 @@ func (loop *Loop) step(ctx context.Context, now time.Time) error {
 		return err
 	}
 	loop.observation = copyObservation(observation)
+	loop.accumulateRecoveriesLocked(observation)
 	loop.lastOK = now
 	loop.up = true
 	loop.ready.Store(true)
 	loop.mu.Unlock()
 	loop.offerObservation(observation)
 	return nil
+}
+
+// accumulateRecoveriesLocked adds one step's exhausted-delivery recoveries to
+// the process total. A negative count cannot be represented in the metric and a
+// wrapped total would read as a drop, so both are refused rather than exported.
+func (loop *Loop) accumulateRecoveriesLocked(observation Observation) {
+	recovered := observation.ExhaustedDeliveriesRecovered
+	if recovered <= 0 {
+		return
+	}
+	if loop.exhaustedRecoveries > math.MaxUint64-uint64(recovered) {
+		return
+	}
+	loop.exhaustedRecoveries += uint64(recovered)
 }
 
 func (loop *Loop) offerObservation(observation Observation) {
@@ -389,6 +411,7 @@ func (loop *Loop) WritePrometheus(output io.Writer) error {
 	}
 	loop.mu.Lock()
 	observation := copyObservation(loop.observation)
+	exhaustedRecoveries := loop.exhaustedRecoveries
 	lastOK := loop.lastOK
 	up := loop.up
 	now := loop.clock.Now()
@@ -413,6 +436,7 @@ func (loop *Loop) WritePrometheus(output io.Writer) error {
 	} else {
 		text.WriteString("0\n")
 	}
+	fmt.Fprintf(&text, "# HELP sync_dispatch_exhausted_delivery_recoveries_total Coordinator deliveries reclaimed after River spent their whole attempt budget.\n# TYPE sync_dispatch_exhausted_delivery_recoveries_total counter\nsync_dispatch_exhausted_delivery_recoveries_total %d\n", exhaustedRecoveries)
 	text.WriteString("# HELP sync_dispatch_observer_up Whether the observer loop is currently healthy.\n# TYPE sync_dispatch_observer_up gauge\nsync_dispatch_observer_up ")
 	if up {
 		text.WriteString("1\n")

--- a/internal/syncreconciler/loop_test.go
+++ b/internal/syncreconciler/loop_test.go
@@ -160,6 +160,14 @@ func TestLoopImmediateObservationGatesReadinessAndExportsGauges(t *testing.T) {
 			t.Fatalf("metrics missing %q:\n%s", want, metrics.String())
 		}
 	}
+	// This replaced a blanket `!strings.Contains(metrics, " counter\n")`, whose
+	// intent is preserved verbatim from WritePrometheus: "It never accumulates
+	// snapshots: counters would misrepresent current queued work after rows are
+	// dispatched or claims expire." That rationale is about queued work, and it
+	// still holds for every metric it covered. This form is strictly tighter --
+	// the old substring check would have accepted a *gauge* named `_total`,
+	// which is the instrument that actually lies about a recovery event.
+	//
 	// Everything derived from an Observation snapshot must stay a gauge: a
 	// counter would keep reporting queued work that has since dispatched or
 	// expired. The exhausted-delivery total is the one deliberate exception --

--- a/internal/syncreconciler/loop_test.go
+++ b/internal/syncreconciler/loop_test.go
@@ -741,3 +741,51 @@ func assertRecoveryTotal(t *testing.T, loop *Loop, want int) {
 		t.Fatalf("metrics missing %q:\n%s", strings.TrimSuffix(line, "\n"), metrics.String())
 	}
 }
+
+// TestLoopCountsExhaustedDeliveryRecoveriesFromAFailedStep pins the count
+// against the step's own outcome. The repair commits before any later stage
+// runs, so its reclaims are durable even when the step as a whole fails.
+// Counting only successful steps would drop reclaims that happened while the
+// pipeline was degraded -- which is precisely when a delivery cycling on
+// exhaustion is a plausible cause of the degradation.
+func TestLoopCountsExhaustedDeliveryRecoveriesFromAFailedStep(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.August, 20, 12, 0, 0, 0, time.UTC)}
+	calls := make(chan struct{}, 2)
+	var steps atomic.Int64
+	loop, registry := newTestLoop(t, loopStepFunc(func(context.Context, time.Time, int) (Observation, error) {
+		observation := testObservation()
+		defer func() { calls <- struct{}{} }()
+		// The loop refuses to start on a failed initial observation, so the
+		// failure under test has to be the second step.
+		if steps.Add(1) == 1 {
+			return observation, nil
+		}
+		observation.ExhaustedDeliveriesRecovered = 4
+		return observation, ErrUnknownKind
+	}), clock)
+	openReadinessGate(t, registry)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := loop.Shutdown(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	<-calls
+	assertRecoveryTotal(t, loop, 0)
+	clock.mu.Lock()
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	ticker.ticks <- clock.Now().Add(time.Second)
+	<-calls
+	select {
+	case err := <-loop.Errors():
+		if !errors.Is(err, ErrUnknownKind) {
+			t.Fatalf("loop error = %v, want ErrUnknownKind", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop never reported the failed step")
+	}
+	assertRecoveryTotal(t, loop, 4)
+}

--- a/internal/syncreconciler/loop_test.go
+++ b/internal/syncreconciler/loop_test.go
@@ -160,8 +160,21 @@ func TestLoopImmediateObservationGatesReadinessAndExportsGauges(t *testing.T) {
 			t.Fatalf("metrics missing %q:\n%s", want, metrics.String())
 		}
 	}
-	if strings.Contains(metrics.String(), " counter\n") ||
-		strings.Contains(metrics.String(), PredicateVersion) ||
+	// Everything derived from an Observation snapshot must stay a gauge: a
+	// counter would keep reporting queued work that has since dispatched or
+	// expired. The exhausted-delivery total is the one deliberate exception --
+	// it counts events that already happened, where a gauge would instead
+	// erase the evidence on the next step (CHAOS-3951) -- so it is pinned by
+	// name here rather than blanket-permitting counters.
+	for _, line := range strings.Split(metrics.String(), "\n") {
+		if !strings.HasSuffix(line, " counter") {
+			continue
+		}
+		if line != "# TYPE sync_dispatch_exhausted_delivery_recoveries_total counter" {
+			t.Fatalf("unexpected counter metric %q:\n%s", line, metrics.String())
+		}
+	}
+	if strings.Contains(metrics.String(), PredicateVersion) ||
 		strings.Contains(metrics.String(), DigestVersion) ||
 		strings.Contains(metrics.String(), canonicalObservedAt(testObservation().ObservedAt)) ||
 		strings.Contains(metrics.String(), "must-not-be-a-metric-label") {
@@ -669,5 +682,62 @@ func TestLoopWithoutALoggerDoesNotFallBackToSlogDefault(t *testing.T) {
 	}
 	if buf.Len() != 0 {
 		t.Fatalf("nil logger fell back to slog.Default(): %s", buf.String())
+	}
+}
+
+// TestLoopAccumulatesExhaustedDeliveryRecoveriesAcrossSteps pins the recovery
+// total as monotonic. CHAOS-3951's reclaim returns a wedged coordinator
+// delivery to 'pending', which is indistinguishable from a healthy row the
+// moment it is republished; a repeat of this metric is the only thing that
+// separates a run that recovered once from one cycling forever. Reporting the
+// last step's count instead of the running total would show zero for every
+// scrape that did not land inside the same step as the reclaim.
+func TestLoopAccumulatesExhaustedDeliveryRecoveriesAcrossSteps(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.August, 20, 12, 0, 0, 0, time.UTC)}
+	recoveries := []int64{2, 0, 1}
+	var index atomic.Int64
+	calls := make(chan struct{}, len(recoveries))
+	loop, registry := newTestLoop(t, loopStepFunc(func(context.Context, time.Time, int) (Observation, error) {
+		observation := testObservation()
+		position := int(index.Add(1)) - 1
+		if position < len(recoveries) {
+			observation.ExhaustedDeliveriesRecovered = recoveries[position]
+		}
+		calls <- struct{}{}
+		return observation, nil
+	}), clock)
+	openReadinessGate(t, registry)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := loop.Shutdown(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	<-calls
+	assertRecoveryTotal(t, loop, 2)
+
+	clock.mu.Lock()
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	for step := 1; step < len(recoveries); step++ {
+		ticker.ticks <- clock.Now().Add(time.Duration(step) * time.Second)
+		<-calls
+	}
+	// The middle step recovered nothing; the total must still carry the first
+	// step's two, and the last step's one must add rather than replace.
+	assertRecoveryTotal(t, loop, 3)
+}
+
+func assertRecoveryTotal(t *testing.T, loop *Loop, want int) {
+	t.Helper()
+	var metrics bytes.Buffer
+	if err := loop.WritePrometheus(&metrics); err != nil {
+		t.Fatal(err)
+	}
+	line := fmt.Sprintf("sync_dispatch_exhausted_delivery_recoveries_total %d\n", want)
+	if !strings.Contains(metrics.String(), line) {
+		t.Fatalf("metrics missing %q:\n%s", strings.TrimSuffix(line, "\n"), metrics.String())
 	}
 }

--- a/internal/syncreconciler/observer.go
+++ b/internal/syncreconciler/observer.go
@@ -84,17 +84,26 @@ type KindObservation struct {
 // make arbitrary UTF-8 kinds unambiguous. Metrics deliberately omit all string
 // parity fields.
 type Observation struct {
-	Kinds             []KindObservation
-	UnknownKindCount  int64
-	CeleryDuePending  int64
-	RiverDuePending   int64
-	SampledCandidates int64
-	Truncated         bool
-	ObservedAt        time.Time
-	Limit             int
-	PredicateVersion  string
-	DigestVersion     string
-	CandidateDigest   string
+	Kinds            []KindObservation
+	UnknownKindCount int64
+	// ExhaustedDeliveriesRecovered counts the coordinator deliveries this step
+	// reclaimed after River spent their whole attempt budget (CHAOS-3951). It
+	// describes an action the mutation pipeline took, not outbox state, so the
+	// read-only Observer always leaves it zero. It exists on Observation
+	// because Loop is the only component holding the metrics registration, and
+	// a repeat here is the sole evidence that a run is cycling rather than
+	// progressing -- the reclaimed row is otherwise indistinguishable from a
+	// healthy one.
+	ExhaustedDeliveriesRecovered int64
+	CeleryDuePending             int64
+	RiverDuePending              int64
+	SampledCandidates            int64
+	Truncated                    bool
+	ObservedAt                   time.Time
+	Limit                        int
+	PredicateVersion             string
+	DigestVersion                string
+	CandidateDigest              string
 }
 
 type candidateRow struct {

--- a/internal/syncreconciler/pipeline.go
+++ b/internal/syncreconciler/pipeline.go
@@ -153,10 +153,11 @@ func (pipeline *MutationPipeline) Step(
 	); err != nil {
 		return Observation{}, err
 	}
+	// The repair commits its own transaction, so its recoveries are durable
+	// even when a later stage fails. Stamp the count before returning either
+	// way: an observation that reports zero recoveries after rows were in fact
+	// reclaimed would let a cycling run stay under the alert threshold.
 	observation, err := pipeline.observer.Step(ctx, now, limit)
-	if err != nil {
-		return observation, err
-	}
 	observation.ExhaustedDeliveriesRecovered = int64(terminal.ExhaustedRecovered)
-	return observation, nil
+	return observation, err
 }

--- a/internal/syncreconciler/pipeline.go
+++ b/internal/syncreconciler/pipeline.go
@@ -124,8 +124,16 @@ func (pipeline *MutationPipeline) Step(
 	if _, err := pipeline.repair.Step(ctx, now, limit); err != nil {
 		return Observation{}, err
 	}
-	if _, err := pipeline.terminal.Step(ctx, now, limit); err != nil {
+	terminal, err := pipeline.terminal.Step(ctx, now, limit)
+	if err != nil {
 		return Observation{}, err
+	}
+	// A repair cannot recover more rows than its own bounded window. Treating
+	// an out-of-range count as a failed step keeps a miscounting repair from
+	// quietly inflating the recovery metric operators alert on.
+	if terminal.ExhaustedRecovered < 0 || terminal.ExhaustedRecovered > terminal.Recovered ||
+		terminal.Recovered > limit {
+		return Observation{}, ErrUnavailable
 	}
 	if _, err := pipeline.materializer.Step(
 		ctx,
@@ -145,5 +153,10 @@ func (pipeline *MutationPipeline) Step(
 	); err != nil {
 		return Observation{}, err
 	}
-	return pipeline.observer.Step(ctx, now, limit)
+	observation, err := pipeline.observer.Step(ctx, now, limit)
+	if err != nil {
+		return observation, err
+	}
+	observation.ExhaustedDeliveriesRecovered = int64(terminal.ExhaustedRecovered)
+	return observation, nil
 }

--- a/internal/syncreconciler/pipeline.go
+++ b/internal/syncreconciler/pipeline.go
@@ -133,7 +133,17 @@ func (pipeline *MutationPipeline) Step(
 	// quietly inflating the recovery metric operators alert on.
 	if terminal.ExhaustedRecovered < 0 || terminal.ExhaustedRecovered > terminal.Recovered ||
 		terminal.Recovered > limit {
+		// The count itself is untrustworthy here, so it is the one case that
+		// deliberately reports nothing rather than a number it cannot stand behind.
 		return Observation{}, ErrUnavailable
+	}
+	// The repair commits its own transaction before anything below runs, so its
+	// recoveries are already durable no matter how this step ends. Every return
+	// from here on carries the count: an observation reporting zero recoveries
+	// after rows were in fact reclaimed would let a cycling delivery stay under
+	// its own alert threshold, which is the failure the counter exists to catch.
+	recovered := Observation{
+		ExhaustedDeliveriesRecovered: int64(terminal.ExhaustedRecovered),
 	}
 	if _, err := pipeline.materializer.Step(
 		ctx,
@@ -141,7 +151,7 @@ func (pipeline *MutationPipeline) Step(
 		now.Add(-pipeline.config.StaleDispatchAge),
 		limit,
 	); err != nil {
-		return Observation{}, err
+		return recovered, err
 	}
 	if _, err := pipeline.kernel.Step(
 		ctx,
@@ -151,13 +161,9 @@ func (pipeline *MutationPipeline) Step(
 		pipeline.publish,
 		pipeline.postSync,
 	); err != nil {
-		return Observation{}, err
+		return recovered, err
 	}
-	// The repair commits its own transaction, so its recoveries are durable
-	// even when a later stage fails. Stamp the count before returning either
-	// way: an observation that reports zero recoveries after rows were in fact
-	// reclaimed would let a cycling run stay under the alert threshold.
 	observation, err := pipeline.observer.Step(ctx, now, limit)
-	observation.ExhaustedDeliveriesRecovered = int64(terminal.ExhaustedRecovered)
+	observation.ExhaustedDeliveriesRecovered = recovered.ExhaustedDeliveriesRecovered
 	return observation, err
 }

--- a/internal/syncreconciler/pipeline_test.go
+++ b/internal/syncreconciler/pipeline_test.go
@@ -244,3 +244,76 @@ func TestMutationPipelineRejectsIncompleteComposition(t *testing.T) {
 		t.Fatalf("missing terminal repair error = %v", err)
 	}
 }
+
+// TestMutationPipelineReportsExhaustedDeliveryRecoveries pins the count from
+// the terminal-delivery repair onto the observation the metrics loop reads.
+// The repair's own return value was previously discarded, which is why
+// CHAOS-3951's reclaim would otherwise be invisible: the row it rescues returns
+// to 'pending' and looks exactly like one that never wedged.
+func TestMutationPipelineReportsExhaustedDeliveryRecoveries(t *testing.T) {
+	pipeline, err := newRecoveryCountingPipeline(
+		t,
+		TerminalDeliveryRepairResult{Recovered: 3, ExhaustedRecovered: 2},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := pipeline.Step(context.Background(), time.Now().UTC(), 17)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation.ExhaustedDeliveriesRecovered != 2 {
+		t.Fatalf(
+			"ExhaustedDeliveriesRecovered = %d, want the exhausted subset (2), not the total (3) or zero",
+			observation.ExhaustedDeliveriesRecovered,
+		)
+	}
+}
+
+// A repair reporting more exhausted recoveries than recoveries, or more
+// recoveries than its own window allows, is miscounting. Exporting that would
+// inflate the metric operators page on, so the step fails instead.
+func TestMutationPipelineRejectsImpossibleRecoveryCounts(t *testing.T) {
+	for name, result := range map[string]TerminalDeliveryRepairResult{
+		"exhausted exceeds recovered": {Recovered: 1, ExhaustedRecovered: 2},
+		"negative exhausted":          {Recovered: 1, ExhaustedRecovered: -1},
+		"recovered exceeds limit":     {Recovered: 18, ExhaustedRecovered: 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			pipeline, err := newRecoveryCountingPipeline(t, result)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := pipeline.Step(context.Background(), time.Now().UTC(), 17); !errors.Is(err, ErrUnavailable) {
+				t.Fatalf("err = %v, want ErrUnavailable", err)
+			}
+		})
+	}
+}
+
+func newRecoveryCountingPipeline(
+	t *testing.T,
+	terminal TerminalDeliveryRepairResult,
+) (*MutationPipeline, error) {
+	t.Helper()
+	return NewMutationPipeline(
+		pipelineLeaseRepairFunc(func(context.Context, time.Time, int) (LeaseRepairResult, error) {
+			return LeaseRepairResult{}, nil
+		}),
+		pipelineTerminalDeliveryRepairFunc(func(context.Context, time.Time, int) (TerminalDeliveryRepairResult, error) {
+			return terminal, nil
+		}),
+		pipelineMaterializerFunc(func(context.Context, time.Time, time.Time, int) (MaterializerResult, error) {
+			return MaterializerResult{}, nil
+		}),
+		pipelineKernelFunc(func(context.Context, time.Time, int, time.Duration, AtLeastOncePublisher, PostSyncHandoff) (KernelResult, error) {
+			return KernelResult{}, nil
+		}),
+		pipelineObserverFunc(func(context.Context, time.Time, int) (Observation, error) {
+			return Observation{CandidateDigest: "sha256:result"}, nil
+		}),
+		AtLeastOncePublisher(func(context.Context, pgx.Tx, TransportClaim) (string, error) { return "", nil }),
+		PostSyncHandoff(func(context.Context, TransportClaim) error { return nil }),
+		DefaultMutationPipelineConfig(),
+	)
+}

--- a/internal/syncreconciler/pipeline_test.go
+++ b/internal/syncreconciler/pipeline_test.go
@@ -317,3 +317,60 @@ func newRecoveryCountingPipeline(
 		DefaultMutationPipelineConfig(),
 	)
 }
+
+// TestMutationPipelineReportsRecoveriesWhenALaterStageFails closes the gap an
+// adversarial review found in the first attempt at this guard. Counting was
+// moved ahead of the observer's error path but NOT ahead of the materializer's
+// or the kernel's, both of which still returned a zero Observation -- so a
+// transient database error in either one silently discarded reclaims that the
+// repair had already committed, which is exactly the under-report that would
+// hold a cycling delivery below its alert threshold.
+func TestMutationPipelineReportsRecoveriesWhenALaterStageFails(t *testing.T) {
+	sentinel := errors.New("stage unavailable")
+	for name, stages := range map[string]struct{ failMaterializer, failKernel bool }{
+		"materializer fails": {failMaterializer: true},
+		"kernel fails":       {failKernel: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			pipeline, err := NewMutationPipeline(
+				pipelineLeaseRepairFunc(func(context.Context, time.Time, int) (LeaseRepairResult, error) {
+					return LeaseRepairResult{}, nil
+				}),
+				pipelineTerminalDeliveryRepairFunc(func(context.Context, time.Time, int) (TerminalDeliveryRepairResult, error) {
+					return TerminalDeliveryRepairResult{Recovered: 4, ExhaustedRecovered: 4}, nil
+				}),
+				pipelineMaterializerFunc(func(context.Context, time.Time, time.Time, int) (MaterializerResult, error) {
+					if stages.failMaterializer {
+						return MaterializerResult{}, sentinel
+					}
+					return MaterializerResult{}, nil
+				}),
+				pipelineKernelFunc(func(context.Context, time.Time, int, time.Duration, AtLeastOncePublisher, PostSyncHandoff) (KernelResult, error) {
+					if stages.failKernel {
+						return KernelResult{}, sentinel
+					}
+					return KernelResult{}, nil
+				}),
+				pipelineObserverFunc(func(context.Context, time.Time, int) (Observation, error) {
+					return Observation{CandidateDigest: "sha256:result"}, nil
+				}),
+				AtLeastOncePublisher(func(context.Context, pgx.Tx, TransportClaim) (string, error) { return "", nil }),
+				PostSyncHandoff(func(context.Context, TransportClaim) error { return nil }),
+				DefaultMutationPipelineConfig(),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			observation, err := pipeline.Step(context.Background(), time.Now().UTC(), 17)
+			if !errors.Is(err, sentinel) {
+				t.Fatalf("err = %v, want the failing stage's error", err)
+			}
+			if observation.ExhaustedDeliveriesRecovered != 4 {
+				t.Fatalf(
+					"ExhaustedDeliveriesRecovered = %d, want 4: the repair already committed these reclaims",
+					observation.ExhaustedDeliveriesRecovered,
+				)
+			}
+		})
+	}
+}

--- a/internal/syncreconciler/terminal_delivery_repair.go
+++ b/internal/syncreconciler/terminal_delivery_repair.go
@@ -13,18 +13,53 @@ import (
 const (
 	riverUnhandledRescueError    = "Stuck job rescued by JobRescuer"
 	riverUnhandledRescueEvidence = "river_unhandled_rescue"
+	// riverDeliveryExhaustedEvidence is stamped only when River retired a
+	// coordinator delivery by spending its whole attempt budget. It is
+	// deliberately distinct from the rescue evidence: the two branches recover
+	// the same row into the same status, so a shared code would make a
+	// reclaim-loop indistinguishable from an ordinary rescue in the durable
+	// record an operator reads.
+	riverDeliveryExhaustedEvidence = "river_delivery_exhausted"
 )
 
 var riverSchemaPattern = regexp.MustCompile(`^[a-z_][a-z0-9_]{0,62}$`)
 
+// TerminalDeliveryRepairResult counts recovered deliveries. ExhaustedRecovered
+// is the subset that spent River's whole attempt budget and is reported
+// separately because it, unlike a maintenance rescue, can repeat for the same
+// row indefinitely when the underlying failure is deterministic.
 type TerminalDeliveryRepairResult struct {
-	Recovered int
+	Recovered          int
+	ExhaustedRecovered int
 }
 
-// TerminalDeliveryRepair restores a durable dispatch intent only when River
-// itself proves that its global JobRescuer discarded a still-retryable job as
-// unhandled. It deliberately excludes exhausted, cancelled, completed, and
-// ordinary worker failures, so domain retry budgets remain authoritative.
+// TerminalDeliveryRepair restores a durable dispatch intent when River itself
+// proves it retired the delivery without the authoritative domain work having
+// been re-armed. Two proofs qualify, and only two: the global JobRescuer
+// discarded a still-retryable job as unhandled, or the job spent its entire
+// attempt budget. Cancelled, completed, and still-live jobs stay excluded, as
+// does a discard that happened with attempts still on the clock for any other
+// reason -- that is a worker declaring the work permanently failed, and
+// reclaiming it would relitigate a decision the domain already made.
+//
+// The exhausted case is included for the coordinator kinds specifically
+// (CHAOS-3951). The original exclusion was written so that "domain retry
+// budgets remain authoritative", which is correct wherever a second budget
+// exists -- a provider unit carries its own retries, so River giving up merely
+// ends one delivery of work the domain will re-plan. The four sync-dispatch
+// coordinator kinds have no such budget: River's MaxAttempts IS the only one.
+// Excluding them there did not defer to a domain budget, it deferred to
+// nothing, and the SyncRun stayed non-terminal with no error recorded and no
+// path back. Python bounded these kinds at max_retries=0 precisely because
+// redelivery was owned elsewhere and unbounded; this restores that guarantee at
+// the transport instead of the task.
+//
+// Reclaiming is safe here without any additional predicate because the existing
+// ones already prove the delivery is the live one: an outbox row still
+// 'dispatched' whose transport_job_id is this exact job, at the current route
+// generation, cannot have been re-armed by a task body that ran, and cannot be
+// a superseded delivery -- either of those breaks the linkage. So this can
+// never double-deliver work the domain has already moved past.
 type TerminalDeliveryRepair struct {
 	begin beginFunc
 	query string
@@ -68,6 +103,7 @@ func (repair *TerminalDeliveryRepair) Step(
 		limit,
 		riverUnhandledRescueError,
 		riverUnhandledRescueEvidence,
+		riverDeliveryExhaustedEvidence,
 	)
 	if err != nil || rows == nil {
 		return TerminalDeliveryRepairResult{}, ErrUnavailable
@@ -75,8 +111,19 @@ func (repair *TerminalDeliveryRepair) Step(
 	defer rows.Close()
 	result := TerminalDeliveryRepairResult{}
 	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil || !uuidPattern.MatchString(id) {
+		var id, evidence string
+		if err := rows.Scan(&id, &evidence); err != nil || !uuidPattern.MatchString(id) {
+			return TerminalDeliveryRepairResult{}, ErrUnavailable
+		}
+		switch evidence {
+		case riverUnhandledRescueEvidence:
+		case riverDeliveryExhaustedEvidence:
+			result.ExhaustedRecovered++
+		default:
+			// The evidence code is chosen by this statement, so an unknown one
+			// means the row was recovered under a branch this code does not
+			// know it has. Fail the whole step rather than report a count that
+			// describes something else.
 			return TerminalDeliveryRepairResult{}, ErrUnavailable
 		}
 		result.Recovered++
@@ -93,12 +140,30 @@ func (repair *TerminalDeliveryRepair) Step(
 // The queue role owns the River schema and UPDATE on sync_dispatch_outbox.
 // The route generation fence prevents recovery after an operator has changed
 // transport ownership. FOR UPDATE SKIP LOCKED makes replicas converge on at
-// most one replacement delivery. The exact latest-error plus remaining-attempt
-// predicate identifies River v0.40's unhandled-kind rescue branch; an ordinary
-// terminal worker failure never satisfies both clauses.
+// most one replacement delivery.
+//
+// Two disjoint recovery branches share every other predicate, and each stamps
+// its own durable evidence code:
+//
+//   - remaining attempts AND the exact latest-error text identifies River
+//     v0.40's unhandled-kind rescue branch; an ordinary terminal worker failure
+//     never satisfies both clauses.
+//   - a spent attempt budget identifies exhaustion, whatever the last error
+//     said. The error text is deliberately NOT matched here: the whole point is
+//     that a coordinator bridge failure carries arbitrary transport text.
+//
+// The branches are written as an explicit disjunction rather than by relaxing
+// the attempt comparison, so that a discard with attempts remaining still
+// requires the rescue sentinel. Republishing does not collide with the retired
+// job's unique key: the publisher includes the outbox attempt counter in its
+// args and the claim increments it, so each redelivery has distinct args.
 const repairUnhandledRiverDeliverySQL = `
 WITH candidates AS (
-	SELECT outbox.id
+	SELECT outbox.id,
+		CASE
+			WHEN job.attempt >= job.max_attempts THEN $5::text
+			ELSE $4::text
+		END AS recovery_code
 	FROM public.sync_dispatch_outbox AS outbox
 	JOIN public.sync_runs AS run
 		ON run.id = outbox.sync_run_id
@@ -115,9 +180,11 @@ WITH candidates AS (
 		AND route.paused = FALSE
 		AND job.state::text = 'discarded'
 		AND job.finalized_at IS NOT NULL
-		AND job.attempt < job.max_attempts
 		AND cardinality(job.errors) > 0
-		AND (job.errors[cardinality(job.errors)]->>'error') = $3
+		AND (
+			job.attempt >= job.max_attempts
+			OR (job.errors[cardinality(job.errors)]->>'error') = $3
+		)
 	ORDER BY outbox.dispatched_at, outbox.id
 	FOR UPDATE OF outbox, job SKIP LOCKED
 	LIMIT $2::int
@@ -125,7 +192,7 @@ WITH candidates AS (
 UPDATE public.sync_dispatch_outbox AS outbox
 SET status = 'pending',
 	available_at = $1,
-	last_error = $4,
+	last_error = candidates.recovery_code,
 	dispatched_at = NULL,
 	dispatched_transport = NULL,
 	dispatched_route_generation = NULL,
@@ -137,5 +204,5 @@ SET status = 'pending',
 	updated_at = $1
 FROM candidates
 WHERE outbox.id = candidates.id
-RETURNING outbox.id::text
+RETURNING outbox.id::text, candidates.recovery_code
 `

--- a/internal/syncreconciler/terminal_delivery_repair.go
+++ b/internal/syncreconciler/terminal_delivery_repair.go
@@ -75,7 +75,7 @@ func NewTerminalDeliveryRepair(
 	jobTable := pgx.Identifier{riverSchema, "river_job"}.Sanitize()
 	return &TerminalDeliveryRepair{
 		begin: queueControlPool.Begin,
-		query: fmt.Sprintf(repairUnhandledRiverDeliverySQL, jobTable),
+		query: fmt.Sprintf(repairTerminalRiverDeliverySQL, jobTable),
 	}, nil
 }
 
@@ -157,7 +157,7 @@ func (repair *TerminalDeliveryRepair) Step(
 // requires the rescue sentinel. Republishing does not collide with the retired
 // job's unique key: the publisher includes the outbox attempt counter in its
 // args and the claim increments it, so each redelivery has distinct args.
-const repairUnhandledRiverDeliverySQL = `
+const repairTerminalRiverDeliverySQL = `
 WITH candidates AS (
 	SELECT outbox.id,
 		CASE

--- a/internal/syncreconciler/terminal_delivery_repair_integration_test.go
+++ b/internal/syncreconciler/terminal_delivery_repair_integration_test.go
@@ -10,6 +10,8 @@ import (
 
 	postgresstore "github.com/full-chaos/dev-health-ops/internal/storage/postgres"
 	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchruntime"
 	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -116,8 +118,13 @@ func TestTerminalDeliveryRepairReclaimsExhaustedCoordinatorDelivery(t *testing.T
 			t.Fatalf("repair step: %v", err)
 		}
 		if result != (TerminalDeliveryRepairResult{}) {
-			t.Fatalf("result = %#v, want no recovery", result)
+			t.Fatalf(
+				"result = %#v: a permanent discard was reclaimed, relitigating a terminal decision the worker already made",
+				result,
+			)
 		}
+		// last_error must remain unset: any stamped code proves a recovery
+		// branch ran, which is the failure here regardless of which one.
 		assertOutboxDelivery(t, ctx, adminPool, "dispatched", "", true)
 	})
 
@@ -174,6 +181,112 @@ func TestTerminalDeliveryRepairReclaimsExhaustedCoordinatorDelivery(t *testing.T
 			t.Fatalf("result = %#v, want no recovery", result)
 		}
 		assertOutboxDelivery(t, ctx, adminPool, "dispatched", "", true)
+	})
+
+	// The safety argument for including exhaustion is that the pre-existing
+	// predicates already prove the delivery is the live one. These two controls
+	// hold that argument to a test instead of leaving it as prose in a comment:
+	// both seed an exhausted job whose work the domain has ALREADY moved past,
+	// and the repair must decline both. Without them, a refactor that loosened
+	// the outbox-to-job linkage would produce a double delivery while every
+	// other subtest here still passed -- verified by mutation: dropping
+	// `job.id::text = outbox.transport_job_id` from the join fails only the
+	// superseded case.
+	//
+	// Both controls are killed by the LINKAGE predicate, not by the
+	// `status = 'dispatched'` fence: a real re-arm nulls transport_job_id too
+	// (Python's upsert and this repair both do), so no reachable state has a
+	// pending row still pointing at a job. Mutating the status fence alone
+	// therefore changes nothing observable here. That is redundancy in the SQL,
+	// not a gap in these tests, and it is recorded so the next reader does not
+	// mistake one for the other.
+	t.Run("delivery whose body already re-armed the row is never reclaimed", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		jobID := seedExhaustionDelivery(t, ctx, adminPool, riverClient, now, "running")
+		discardRiverJob(t, ctx, adminPool, jobID, now, 5, 5, exhaustionBridgeError)
+		// The compatibility body ran and stamped its own wakeup, returning the
+		// row to 'pending'. The run is already progressing; a reclaim here
+		// would publish a second delivery of work that is under way.
+		if _, err := adminPool.Exec(
+			ctx,
+			`UPDATE public.sync_dispatch_outbox
+			 SET status = 'pending', available_at = $2, dispatched_at = NULL,
+				 dispatched_transport = NULL, dispatched_route_generation = NULL,
+				 transport_job_id = NULL, updated_at = $2
+			 WHERE id = $1`,
+			exhaustionRunID,
+			now,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := repair.Step(ctx, now, 10)
+		if err != nil {
+			t.Fatalf("repair step: %v", err)
+		}
+		if result != (TerminalDeliveryRepairResult{}) {
+			t.Fatalf("result = %#v, want no recovery", result)
+		}
+		var status string
+		var lastError *string
+		if err := adminPool.QueryRow(
+			ctx,
+			`SELECT status, last_error FROM public.sync_dispatch_outbox WHERE id = $1`,
+			exhaustionRunID,
+		).Scan(&status, &lastError); err != nil {
+			t.Fatal(err)
+		}
+		if status != "pending" || lastError != nil {
+			t.Fatalf("re-armed row was mutated: status=%q last_error=%v", status, lastError)
+		}
+	})
+
+	t.Run("superseded delivery is never reclaimed under a newer one", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		retired := seedExhaustionDelivery(t, ctx, adminPool, riverClient, now, "running")
+		discardRiverJob(t, ctx, adminPool, retired, now, 5, 5, exhaustionBridgeError)
+		// A newer delivery already replaced the exhausted one and is in flight.
+		// The exhausted job still sits in river_job, and only the
+		// transport_job_id linkage distinguishes it from the live delivery.
+		replacement, err := riverClient.Insert(ctx, kernelRiverArgs{OutboxID: exhaustionRunID}, &river.InsertOpts{
+			Queue: "sync",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adminPool.Exec(
+			ctx,
+			`UPDATE public.sync_dispatch_outbox
+			 SET transport_job_id = $2, dispatched_at = $3, updated_at = $3
+			 WHERE id = $1`,
+			exhaustionRunID,
+			strconv.FormatInt(replacement.Job.ID, 10),
+			now,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := repair.Step(ctx, now, 10)
+		if err != nil {
+			t.Fatalf("repair step: %v", err)
+		}
+		if result != (TerminalDeliveryRepairResult{}) {
+			t.Fatalf("result = %#v, want no recovery of a superseded delivery", result)
+		}
+		var status, transportID string
+		if err := adminPool.QueryRow(
+			ctx,
+			`SELECT status, transport_job_id FROM public.sync_dispatch_outbox WHERE id = $1`,
+			exhaustionRunID,
+		).Scan(&status, &transportID); err != nil {
+			t.Fatal(err)
+		}
+		if status != "dispatched" || transportID != strconv.FormatInt(replacement.Job.ID, 10) {
+			t.Fatalf(
+				"live delivery was disturbed: status=%q transport_job_id=%s want dispatched/%d",
+				status, transportID, replacement.Job.ID,
+			)
+		}
 	})
 
 	t.Run("exhausted delivery on a paused route is never reclaimed", func(t *testing.T) {
@@ -332,4 +445,150 @@ func assertOutboxDelivery(
 			dispatchAt,
 		)
 	}
+}
+
+// TestReclaimedCoordinatorDeliveryRepublishesAsANewRiverJob pins the fact the
+// whole reclaim silently depends on.
+//
+// The coordinator publisher inserts with UniqueOpts{ByArgs, ByState:
+// JobStates()}, and JobStates() includes 'discarded'. A byte-identical
+// re-publish after a reclaim would therefore be swallowed as a duplicate of the
+// job River just retired, and verifyInsert does not inspect
+// UniqueSkippedAsDuplicate -- so Publish would return the RETIRED job's id and
+// report success. The outbox would cycle pending -> dispatched -> pending
+// forever while no worker ever ran, which is a worse failure than the wedge
+// this repair exists to fix.
+//
+// It works only because TransportArgs carries DeliveryAttempt and the Kernel's
+// claim increments outbox.attempts, giving every redelivery distinct args and
+// so a distinct unique key. Nothing else enforces that. This test fails if
+// DeliveryAttempt is dropped from the args shape, or if the claim stops
+// advancing the attempt counter.
+func TestReclaimedCoordinatorDeliveryRepublishesAsANewRiverJob(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	adminPool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer adminPool.Close()
+	if err := createKernelIntegrationFixture(ctx, adminPool); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := riverstore.ApplyPinnedMigrations(ctx, adminPool, riverstore.MigrationOptions{
+		Schema:     "river",
+		DomainRole: kernelDomainRole,
+		QueueRole:  kernelQueueRole,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	riverClient, err := river.NewClient(riverpgxv5.New(adminPool), &river.Config{Schema: "river"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publisher, err := syncdispatchruntime.NewPublisher(riverClient, syncdispatchruntime.PublisherOptions{
+		Queue:       syncdispatchcontract.RiverQueue,
+		MaxAttempts: 5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reference := syncdispatchruntime.DomainReference{
+		OrganizationID: "00000000-0000-4000-8000-0000000044f0",
+		SyncRunID:      exhaustionRunID,
+	}
+	publish := func(attempt int64) (string, error) {
+		tx, txErr := adminPool.Begin(ctx)
+		if txErr != nil {
+			return "", txErr
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		id, publishErr := publisher.Publish(ctx, tx, syncdispatchruntime.Claim{
+			OutboxID:        exhaustionRunID,
+			Kind:            syncdispatchcontract.KindDispatchSyncRun,
+			RouteGeneration: 7,
+			DeliveryAttempt: attempt,
+		}, reference)
+		if publishErr != nil {
+			return "", publishErr
+		}
+		return id, tx.Commit(ctx)
+	}
+
+	resetKernelIntegrationTables(t, ctx, adminPool)
+	first, err := publish(1)
+	if err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+
+	// Re-publishing the SAME delivery attempt must NOT mint a second job: that
+	// is the deduplication the unique key is there to provide, and it is what
+	// makes the assertion below meaningful rather than accidental.
+	same, err := publish(1)
+	if err != nil {
+		t.Fatalf("republish at the same attempt: %v", err)
+	}
+	if same != first {
+		t.Fatalf("republish at attempt 1 minted job %s, want the existing %s", same, first)
+	}
+
+	// Retire the delivery exactly as exhaustion does, then reclaim it.
+	firstID, err := strconv.ParseInt(first, 10, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := adminPool.Exec(
+		ctx,
+		`INSERT INTO public.sync_runs (id, status) VALUES ($1, 'running')
+		 ON CONFLICT (id) DO UPDATE SET status = 'running'`,
+		exhaustionRunID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	discardRiverJob(t, ctx, adminPool, firstID, time.Now().UTC(), 5, 5, exhaustionBridgeError)
+
+	// The next claim advances outbox.attempts, so the redelivery carries a
+	// different attempt -- and must therefore reach River as a NEW job rather
+	// than resolving to the discarded one.
+	second, err := publish(2)
+	if err != nil {
+		t.Fatalf("republish after reclaim: %v", err)
+	}
+	if second == first {
+		t.Fatalf(
+			"redelivery was deduplicated into the retired job %s: the reclaim would loop forever without ever running a worker",
+			first,
+		)
+	}
+	var state string
+	if err := adminPool.QueryRow(
+		ctx,
+		`SELECT state::text FROM river.river_job WHERE id = $1`,
+		mustParseJobID(t, second),
+	).Scan(&state); err != nil {
+		t.Fatal(err)
+	}
+	if state != "available" {
+		t.Fatalf("redelivered job state = %q, want an executable job", state)
+	}
+}
+
+func mustParseJobID(t *testing.T, id string) int64 {
+	t.Helper()
+	parsed, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
 }

--- a/internal/syncreconciler/terminal_delivery_repair_integration_test.go
+++ b/internal/syncreconciler/terminal_delivery_repair_integration_test.go
@@ -1,0 +1,335 @@
+//go:build integration
+
+package syncreconciler
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	postgresstore "github.com/full-chaos/dev-health-ops/internal/storage/postgres"
+	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+)
+
+const (
+	exhaustionRunID = "00000000-0000-4000-8000-000000004401"
+	// A coordinator bridge failure carries the transport error text, never
+	// River's maintenance-rescue sentinel. CHAOS-3951's wedge is exactly the
+	// case where these two differ.
+	exhaustionBridgeError = "sync dispatch bridge request failed: status=503"
+)
+
+// TestTerminalDeliveryRepairReclaimsExhaustedCoordinatorDelivery pins
+// CHAOS-3951 against the real River schema and the least-privilege queue role.
+//
+// The subtests deliberately assert WHICH recovery branch fired by reading the
+// durable evidence code back off the row, not merely that the row returned to
+// 'pending'. A repair that stamped one shared code, or that reclaimed every
+// discarded job, would drive the outbox to the same status and pass a
+// state-only assertion while being wrong in a way that either hides the wedge
+// or resurrects a deliberately permanent failure.
+func TestTerminalDeliveryRepairReclaimsExhaustedCoordinatorDelivery(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+
+	adminPool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer adminPool.Close()
+	if err := createKernelIntegrationFixture(ctx, adminPool); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := riverstore.ApplyPinnedMigrations(ctx, adminPool, riverstore.MigrationOptions{
+		Schema:     "river",
+		DomainRole: kernelDomainRole,
+		QueueRole:  kernelQueueRole,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	queuePool, err := pgxpool.New(
+		ctx,
+		kernelRoleURI(t, instance.URI, kernelQueueRole, kernelQueuePassword),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer queuePool.Close()
+	if err := postgresstore.CheckQueueAuthorization(ctx, queuePool, kernelQueueRole, "river"); err != nil {
+		t.Fatalf("queue authorization: %v", err)
+	}
+	riverClient, err := river.NewClient(
+		riverpgxv5.New(adminPool),
+		&river.Config{Schema: "river"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repair, err := NewTerminalDeliveryRepair(queuePool, "river")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.August, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("exhausted delivery is reclaimed under its own evidence code", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		jobID := seedExhaustionDelivery(t, ctx, adminPool, riverClient, now, "running")
+		discardRiverJob(t, ctx, adminPool, jobID, now, 5, 5, exhaustionBridgeError)
+
+		result, err := repair.Step(ctx, now, 10)
+		if err != nil {
+			t.Fatalf("repair step: %v", err)
+		}
+		if result.Recovered != 1 || result.ExhaustedRecovered != 1 {
+			t.Fatalf("result = %#v, want one recovery counted as exhausted", result)
+		}
+		assertOutboxDelivery(t, ctx, adminPool, "pending", riverDeliveryExhaustedEvidence, false)
+	})
+
+	t.Run("permanent discard before exhaustion stays excluded", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		jobID := seedExhaustionDelivery(t, ctx, adminPool, riverClient, now, "running")
+		// River discards a jobruntime.Permanent failure with attempts still on
+		// the clock. That is a deliberate terminal outcome, not a wedge, and
+		// reclaiming it would loop a failure the worker declared unretryable.
+		discardRiverJob(t, ctx, adminPool, jobID, now, 2, 5, exhaustionBridgeError)
+
+		result, err := repair.Step(ctx, now, 10)
+		if err != nil {
+			t.Fatalf("repair step: %v", err)
+		}
+		if result != (TerminalDeliveryRepairResult{}) {
+			t.Fatalf("result = %#v, want no recovery", result)
+		}
+		assertOutboxDelivery(t, ctx, adminPool, "dispatched", "", true)
+	})
+
+	t.Run("unhandled rescue keeps the pre-existing rescue evidence code", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		jobID := seedExhaustionDelivery(t, ctx, adminPool, riverClient, now, "running")
+		discardRiverJob(t, ctx, adminPool, jobID, now, 2, 5, riverUnhandledRescueError)
+
+		result, err := repair.Step(ctx, now, 10)
+		if err != nil {
+			t.Fatalf("repair step: %v", err)
+		}
+		if result.Recovered != 1 || result.ExhaustedRecovered != 0 {
+			t.Fatalf("result = %#v, want one recovery not counted as exhausted", result)
+		}
+		assertOutboxDelivery(t, ctx, adminPool, "pending", riverUnhandledRescueEvidence, false)
+	})
+
+	t.Run("exhausted delivery on a terminal run is never reclaimed", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		jobID := seedExhaustionDelivery(t, ctx, adminPool, riverClient, now, "success")
+		discardRiverJob(t, ctx, adminPool, jobID, now, 5, 5, exhaustionBridgeError)
+
+		result, err := repair.Step(ctx, now, 10)
+		if err != nil {
+			t.Fatalf("repair step: %v", err)
+		}
+		if result != (TerminalDeliveryRepairResult{}) {
+			t.Fatalf("result = %#v, want no recovery", result)
+		}
+		assertOutboxDelivery(t, ctx, adminPool, "dispatched", "", true)
+	})
+
+	t.Run("live job at the attempt ceiling is never reclaimed", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		jobID := seedExhaustionDelivery(t, ctx, adminPool, riverClient, now, "running")
+		// Same attempt arithmetic as an exhausted job, but River has not
+		// finalized it: the fifth attempt is still executing.
+		if _, err := adminPool.Exec(
+			ctx,
+			`UPDATE river.river_job
+			 SET attempt = 5, max_attempts = 5, state = 'running'
+			 WHERE id = $1`,
+			jobID,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := repair.Step(ctx, now, 10)
+		if err != nil {
+			t.Fatalf("repair step: %v", err)
+		}
+		if result != (TerminalDeliveryRepairResult{}) {
+			t.Fatalf("result = %#v, want no recovery", result)
+		}
+		assertOutboxDelivery(t, ctx, adminPool, "dispatched", "", true)
+	})
+
+	t.Run("exhausted delivery on a paused route is never reclaimed", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		jobID := seedExhaustionDelivery(t, ctx, adminPool, riverClient, now, "running")
+		discardRiverJob(t, ctx, adminPool, jobID, now, 5, 5, exhaustionBridgeError)
+		if _, err := adminPool.Exec(
+			ctx,
+			`UPDATE public.sync_dispatch_transport_routes
+			 SET paused = TRUE, paused_at = $1
+			 WHERE kind = 'dispatch_sync_run'`,
+			now,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := repair.Step(ctx, now, 10)
+		if err != nil {
+			t.Fatalf("repair step: %v", err)
+		}
+		if result != (TerminalDeliveryRepairResult{}) {
+			t.Fatalf("result = %#v, want no recovery", result)
+		}
+		assertOutboxDelivery(t, ctx, adminPool, "dispatched", "", true)
+	})
+}
+
+// seedExhaustionDelivery reproduces the state a coordinator delivery is left in
+// once the Kernel has published it: the outbox row is 'dispatched' and points
+// at a live River job through transport_job_id and the route generation.
+func seedExhaustionDelivery(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	client *river.Client[pgx.Tx],
+	now time.Time,
+	runStatus string,
+) int64 {
+	t.Helper()
+	seedKernelOutbox(t, ctx, pool, exhaustionRunID, now.Add(-time.Hour))
+	if _, err := pool.Exec(
+		ctx,
+		`UPDATE public.sync_runs SET status = $2 WHERE id = $1`,
+		exhaustionRunID,
+		runStatus,
+	); err != nil {
+		t.Fatal(err)
+	}
+	inserted, err := client.Insert(ctx, kernelRiverArgs{OutboxID: exhaustionRunID}, &river.InsertOpts{
+		Queue: "sync",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(
+		ctx,
+		`UPDATE public.sync_dispatch_outbox
+		 SET status = 'dispatched',
+			 dispatched_at = $2,
+			 dispatched_transport = 'river',
+			 dispatched_route_generation = 7,
+			 transport_job_id = $3,
+			 claim_token = NULL,
+			 claim_expires_at = NULL,
+			 claim_transport = NULL,
+			 claim_route_generation = NULL,
+			 last_error = NULL,
+			 updated_at = $2
+		 WHERE id = $1`,
+		exhaustionRunID,
+		now.Add(-time.Hour),
+		strconv.FormatInt(inserted.Job.ID, 10),
+	); err != nil {
+		t.Fatal(err)
+	}
+	return inserted.Job.ID
+}
+
+// discardRiverJob drives a River row into the exact terminal shape the repair
+// reads: discarded, finalized, with a bounded error history whose last entry
+// carries the supplied text.
+func discardRiverJob(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	jobID int64,
+	now time.Time,
+	attempt int,
+	maxAttempts int,
+	errorText string,
+) {
+	t.Helper()
+	if _, err := pool.Exec(
+		ctx,
+		`UPDATE river.river_job
+		 SET state = 'discarded',
+			 finalized_at = $2,
+			 attempt = $3,
+			 max_attempts = $4,
+			 errors = ARRAY[jsonb_build_object('error', $5::text, 'attempt', $6::int)]
+		 WHERE id = $1`,
+		jobID,
+		now.Add(-time.Minute),
+		attempt,
+		maxAttempts,
+		errorText,
+		attempt,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertOutboxDelivery(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	wantStatus string,
+	wantError string,
+	wantDeliveryRetained bool,
+) {
+	t.Helper()
+	var (
+		status      string
+		lastError   *string
+		transportID *string
+		dispatchAt  *time.Time
+	)
+	if err := pool.QueryRow(
+		ctx,
+		`SELECT status, last_error, transport_job_id, dispatched_at
+		 FROM public.sync_dispatch_outbox WHERE id = $1`,
+		exhaustionRunID,
+	).Scan(&status, &lastError, &transportID, &dispatchAt); err != nil {
+		t.Fatal(err)
+	}
+	if status != wantStatus {
+		t.Fatalf("outbox status = %q, want %q", status, wantStatus)
+	}
+	if wantError == "" {
+		if lastError != nil {
+			t.Fatalf("outbox last_error = %q, want unset", *lastError)
+		}
+	} else if lastError == nil || *lastError != wantError {
+		t.Fatalf("outbox last_error = %v, want %q", lastError, wantError)
+	}
+	if wantDeliveryRetained {
+		if transportID == nil || dispatchAt == nil {
+			t.Fatal("delivery linkage was cleared on a row that must stay dispatched")
+		}
+		return
+	}
+	if transportID != nil || dispatchAt != nil {
+		t.Fatalf(
+			"reclaimed row still points at its delivery: transport_job_id=%v dispatched_at=%v",
+			transportID,
+			dispatchAt,
+		)
+	}
+}

--- a/tests/workers/test_go_worker_alerts.py
+++ b/tests/workers/test_go_worker_alerts.py
@@ -24,6 +24,14 @@ def test_go_worker_alerts_cover_phase_one_runtime_signals() -> None:
         "GoWorkerOldestAvailableJobHigh": "worker_job_oldest_age_seconds",
         "GoWorkerExecutionSaturated": "worker_execution_saturation_ratio",
         "GoWorkerAttemptFailureRateHigh": "worker_job_attempts_total",
+        # CHAOS-3951. Deliberately a separate alert rather than a tighter
+        # threshold on GoWorkerAttemptFailureRateHigh: that rule is a fleet
+        # ratio, and one sync run looping on an exhausted coordinator delivery
+        # never moves it. Aggregate throughput cannot answer whether any single
+        # unit of work reached a terminal state.
+        "SyncDispatchExhaustedDeliveryRecoveryLoop": (
+            "sync_dispatch_exhausted_delivery_recoveries_total"
+        ),
         "GoWorkerDomainStateMismatch": "worker_domain_state_mismatch_total",
         "GoWorkerStreamLagHigh": "worker_stream_lag",
         "GoWorkerStreamPendingTooOld": "worker_stream_oldest_pending_seconds",


### PR DESCRIPTION
Fixes CHAOS-3951.

## The wedge

River bounds the four sync-dispatch coordinator kinds at `MaxAttempts=5`
(`cmd/dev-health-reconciler/dependencies.go`). The coordinator workers return
bridge errors raw, so a web-API outage outliving the attempt span — or five
deterministic bridge failures — discards the delivery. Nothing then recovers it:

- the materializer refuses to re-arm a river-dispatched row (finalize and
  discovery categorically, `post_sync` via `ON CONFLICT DO NOTHING`, and dispatch
  only when a unit already reached `dispatching`-stale or `retrying` — units
  still `planned`, which is the state when the bridge never ran the body, never
  qualify);
- `TerminalDeliveryRepair` excluded the exhausted case via
  `job.attempt < job.max_attempts`.

The `SyncRun` stays non-terminal forever: no error recorded, finalize and
`post_sync` never fire, and the user sees a sync permanently "running".

## Why this is reachable today, and why it never showed up before

Python's `reconcile-sync-dispatch` beat runs every 60s and its re-arm has **no
river fence** — `_terminal_denial_condition` (`sync/dispatch_outbox.py:343`)
denies only `feature_disabled`, and `_dispatchable_run_ids` explicitly includes
runs whose units are `planned`. While Celery beat ran, Python re-armed the
wedged row within a minute and nobody ever saw this.

Production is now in the cutover posture: the running services are
`go-worker-*`, `go-scheduler`, `go-reconciler`, `go-stream-*`, `api`, and `web`
— **no `dev-health-beat`, no Celery worker**, matching
`deploy/kubernetes/go-workers-only.yaml` and `values-go-workers-only.yaml`,
which both take beat to 0 replicas. The Python safety net that masked this is
gone in the deployed posture, not merely in a manifest. That is precisely what
makes the wedge reachable now: the defect was always in the Go code, and the
cutover removed the thing that was hiding it.

## The fix

Add exhaustion as a second recovery branch in `TerminalDeliveryRepair`, under
its own durable evidence code `river_delivery_exhausted`. The rescue branch is
unchanged and still requires the exact `Stuck job rescued by JobRescuer`
sentinel. The two are an explicit disjunction rather than a relaxed comparison,
so a discard with attempts still on the clock — a worker declaring the work
permanently failed — must still prove it was the JobRescuer.

Directions 1 and 2 from the ticket were considered and rejected on what the code
supports:

- **Failing the SyncRun** is unavailable at this seam. The repair runs on
  `queueControlPool`, which is read-only on `sync_runs`/`sync_run_units`. It
  structurally cannot terminalize a run, and widening it would collapse the
  least-privilege split the package is built around.
- **Classifying bridge errors** cannot repair rows already wedged, and the only
  available signal is an HTTP status that reads identically for "web API down"
  and "payload-shape bug".

Direction 4 (a general non-terminal-`sync_runs` detector) is deliberately out of
scope — different pool, different component. Recorded on the ticket, pointing at
CHAOS-3961 as its natural home.

## Why this cannot double-deliver

The pre-existing predicates already prove the delivery is the live one:
`outbox.status = 'dispatched'`, `job.id::text = outbox.transport_job_id`, and a
matching route generation. A body that ran and re-armed the row, or a delivery
already superseded by a newer one, breaks that linkage and is skipped.
`NativePostSyncService.Fanout` runs its whole fanout in one transaction, so a
failed attempt leaves no partial effects for a redelivery to duplicate.

That argument was previously only a comment. It is now two tests (below).

## Not silently reclaimed into a loop

A reclaim returns the row to `pending`, where it is indistinguishable from one
that never wedged — so a deterministic bridge failure would cycle as silently as
the wedge it replaced. `GoWorkerAttemptFailureRateHigh` is a fleet ratio that one
looping run never moves, which is exactly why the original wedge went unnoticed.

The repair's result — previously discarded outright by `MutationPipeline` — now
carries an `ExhaustedRecovered` subset through to a monotonic counter
`sync_dispatch_exhausted_delivery_recoveries_total`, with alert
`SyncDispatchExhaustedDeliveryRecoveryLoop` on a sustained repeat
(`increase(...[2h]) > 3`, `for: 15m`: one looping run clears it at roughly
7-8 reclaims per 2h, a couple of one-off recoveries do not). A gauge would erase
the evidence on the next step, so `Loop`'s gauges-only invariant test was
narrowed to name this one exception rather than dropped — the original
assertion's rationale is quoted verbatim beside the new check.

TEST-EVIDENCE:
- **This adds the first direct test coverage of the coordinator
  `TerminalDeliveryRepair`'s SQL.** It had none — only interface fakes in
  `pipeline_test.go`. It has been running in production unobserved.
- New integration tests against real PostgreSQL and the pinned River schema, run
  through the least-privilege **queue role** (so they also prove the existing
  grants cover the new write).
- Observed failing-first: pre-fix, exactly one subtest red
  (`{Recovered:0, ExhaustedRecovered:0}`); all negative guards green pre-fix.
- Guards assert **which** recovery branch fired by reading the evidence code back
  off the row, so none can pass by observing "the row went pending".
- Two preconditions the fix silently depended on are now pinned:
  - *Redelivery is not swallowed.* The publisher uses
    `UniqueOpts{ByArgs, ByState: JobStates()}`, which includes `discarded`, and
    `verifyInsert` never inspects `UniqueSkippedAsDuplicate`. A byte-identical
    republish would resolve to the job River just retired and report success —
    an endless cycle with no worker ever running, worse than the wedge. It works
    only because `TransportArgs` carries `DeliveryAttempt` and the claim
    increments `outbox.attempts`. Mutation-verified: pinning the attempt to 1
    makes `Publish` return the retired job's id.
  - *No double delivery.* Two controls seed an exhausted job whose work the
    domain has already moved past (body re-armed; superseded by a newer
    delivery) and require the repair to decline both.
- Six hand mutations, all killed for the intended reason, each restored by
  content digest: swapped evidence codes; reclaim-any-discarded-job; dropped job
  linkage; `DeliveryAttempt` pinned to 1; pipeline reporting `Recovered` instead
  of the exhausted subset; counter assigning instead of accumulating. Three
  earlier mutation attempts were discarded because they killed only via an
  unused bind-parameter SQL error rather than the intended assertion.
- Also recorded: mutating the `status = 'dispatched'` fence alone changes nothing
  observable, because a real re-arm nulls `transport_job_id` too. That is
  redundancy in the SQL, not a gap in the tests, and the test file says so.

GATE EVIDENCE — run with `GO_PROVIDER_ROUTES` and `DEV_HEALTH_ENV` unset. Both
are exported by the repo's direnv setup, neither is on `ci/local_validate.sh`'s
env scrub list, and together they enable every provider route — which makes the
default-off tests in `tests/test_sync_units.py` and the scheduler planner oracle
fail for reasons that have nothing to do with any change. Filed as CHAOS-3988.

- `ci/check_go.sh all` — **green**, 118 ok package lines, 0 FAIL.
- `ci/local_validate.sh` — **green**, 8/8 stages, 13247 passed / 639 skipped / 1
  xfailed.
- Integration suites for `internal/syncreconciler`, `internal/syncdispatchruntime`
  and `internal/joboutbox` — green, run explicitly because `check_go.sh all`
  compiles and *plans* integration shards without executing them (CHAOS-3948).
  That is not academic here: running them directly is what caught the two
  sibling guards this branch had to update.

RISK-NOTES:
- Behaviour change: an exhausted coordinator delivery is now redelivered rather
  than left wedged. For a deterministically failing run that is an indefinite
  cycle — the same guarantee Python had (unbounded redelivery, 900s backoff cap),
  now with a counter and an alert Python never had.
- `alerts/rules.yml` may not be scraped at all: no `scrape_configs` are checked
  into this repo, and the acceptance corpus asserts there is no worker-side
  metrics scrape. The new alert is wired exactly as the existing `go_workers`
  rules are, so it inherits whatever the resolution turns out to be. Filed as
  **CHAOS-3985**; not a special case and should not be fixed separately.
- Redelivery after exhaustion means a coordinator body that already ran can run
  again. All four kinds are declared `"at_least_once"` in the checked-in delivery
  contract (`sync/dispatch_outbox.py:68-71`), so tolerating repeated delivery is
  their stated obligation — the wedge was the contract violation, not the fix.
  Verified per kind rather than assumed:
  - `post_sync` — `Fanout` runs in one transaction (plus one deliberately
    isolated savepoint for the best-effort team-autoimport handoff, CHAOS-3946).
    `TestNativePostSyncFanoutIsDuplicateStableAndRollsBackWholeGeneration` runs
    it twice against real PostgreSQL and asserts **7 markers, not 14**.
  - `dispatch_sync_run` — queues only units still pending, behind an atomic claim
    and a `DISPATCHING → RUNNING` CAS.
  - `finalize_sync_run` — guarded by the unique post-dispatch ledger.
  - `reference_discovery` — a CAS claim at `reference_discovery.py:128` returns
    `not_claimed` **before** any provider or ClickHouse work at `:135`, so a
    replay against an already-successful discovery is a no-op.
- Adversarial review raised unbounded auto-import replay. `sync.team_autoimport`
  is not one of the four `sync_dispatch_outbox` kinds and this repair cannot
  reach it. The discovery crash-window artifact (writes land, process dies before
  the success stamp, lease expires, work repeats) is real but pre-existing and
  lease-bounded: it is driven by the discovery lease and the materializer, both
  of which operate today. This repair's scope is strictly the case where the
  bridge failed *before* the body ran — if the body ran, it re-armed the outbox
  itself and the `status = 'dispatched'` predicate excludes the row.
