### PR TITLE
fix(ci): make check_go.sh all genuinely run the integration suite (CHAOS-3948)

### DIFF
--- a/.claude/skills/go-checks/SKILL.md
+++ b/.claude/skills/go-checks/SKILL.md
@@ -19,8 +19,32 @@ uv sync --all-extras --dev                       # once per worktree
 PYTHON="$PWD/.venv/bin/python" bash ci/check_go.sh all
 ```
 
-Expect `rc=0` and ~118 `ok` package lines. Verbs: `all` (full), `fast`
-(format + vet + unit).
+Expect `rc=0`. The `test`/`race` verbs alone report ~118 `ok` package lines;
+`all` additionally runs the FULL integration suite for real (every
+non-denylisted package, unsharded) plus `multi-replica-workers`, both against
+real containers, so expect several more minutes and **Docker running
+locally** — `all` has required Docker unconditionally since `multi-replica-workers`
+was added, `check_integration` is not a new prerequisite, only new time.
+
+Three verbs, in ascending cost:
+- `fast` — format + vet + unit + live-python-oracles + build + contract +
+  multi-replica-workers + an integration shard **plan** only (no execution,
+  no race detector). The quick local-iteration mode.
+- `ci` — `fast` plus the race detector. Byte-for-byte what `all` ran before
+  CHAOS-3948. This is what `go.yml`'s `go-quality` step runs — CI's real
+  integration signal comes from the separate, already-sharded
+  `go-storage-integration-plan`/`-shard` jobs, not from this step, so
+  duplicating a slow unsharded run here would only blow that job's 20-minute
+  budget for no new coverage.
+- `all` (default) — `ci` plus the FULL integration suite executed for real
+  (measured ~24m alone). The honest full local pre-push signal; use this
+  before pushing a Go change, not `ci`.
+
+For fast local iteration on one package without paying for the whole suite:
+
+```bash
+GOWORK=off go test -mod=readonly -tags=integration -count=1 ./internal/<pkg>/...
+```
 
 ## Why both the venv and `PYTHON` are required
 
@@ -65,9 +89,22 @@ CHAOS-3913 (lefthook resolving a global `mypy`/`ruff`), in a third place.
   ```
   A suite that skipped everything is not evidence.
 - **Integration tests are behind a build tag** and are opt-out, not optional:
+  `ci/check_go.sh all` runs them for real (CHAOS-3948 — it used to only PLAN
+  the shards and never execute them, which is exactly the "ok doesn't mean
+  ran" trap above one level up: `rc=0` read as complete while the shards
+  never ran). `fast` and `ci` both still only plan — run `all` or
+  `ci/check_go.sh integration` when you need the real signal.
   ```bash
   go test -tags=integration ./internal/<pkg>/... -count=1
   ```
+- `TestFenceAgainstMigratedPostgres` moved to
+  `internal/syncroute/fence_integration_test.go` (CHAOS-3948, part of the
+  CHAOS-3448 never-run-live-Postgres family). It used to skip unconditionally
+  — nothing in `check_go.sh` or `go.yml` ever set the env var it was gated
+  on, so it had never run in the automated pipeline. Now integration-tagged
+  and wired to `containers.StartPostgres`, the same pattern this package's
+  `control_integration_test.go` already used; it runs for real under `all`
+  or `integration` now.
 - **A red check means no merge.** No diagnosed exclusions.
 
 ## Cross-language parity oracles

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -151,7 +151,13 @@ jobs:
           echo "DEV_HEALTH_CONTRACT_BASE=${base_dir}/contracts/jobs/v1" >> "${GITHUB_ENV}"
 
       - name: Run Go quality gate
-        run: bash ci/check_go.sh all
+        # `ci`, not `all`: CHAOS-3948 made `all` genuinely execute the full
+        # unsharded integration suite (~24m measured) instead of only
+        # planning it, which this job's 20m timeout cannot absorb and would
+        # duplicate the coverage the separate go-storage-integration-plan/
+        # -shard jobs below already provide, sharded and parallel. `ci` is
+        # byte-for-byte what this step ran before CHAOS-3948.
+        run: bash ci/check_go.sh ci
 
       - name: Validate River compatibility harness
         run: bash ci/check_river_compat_static.sh

--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -19,7 +19,7 @@ INTEGRATION_CONTAINER_HARNESS="${ROOT}/internal/testsupport/containers/harness.g
 usage() {
   # Backticks in the literal help text document commands; they are not substitutions.
   # shellcheck disable=SC2016
-  printf '%s\n' 'Usage: ci/check_go.sh [fmt|vet|test|race|live-python-oracles|build|contract|multi-replica-workers|integration-vet|integration-coverage|integration-shard-plan|integration-prepull|integration-shard|integration|fast|all]
+  printf '%s\n' 'Usage: ci/check_go.sh [fmt|vet|test|race|live-python-oracles|build|contract|multi-replica-workers|integration-vet|integration-coverage|integration-shard-plan|integration-prepull|integration-shard|integration|fast|ci|all]
 
   fmt    Check gofmt without modifying files.
   vet    Run go vet ./... in every Go module.
@@ -36,9 +36,9 @@ usage() {
          cache key -- `test`'\''s bare `go test ./...` can return a stale
          cached PASS for a real change to one of those files. NOT an
          optimization opt-out: a run that skips this verb has not tested
-         the oracles at all, so it MUST stay in `all` (and `fast`, since
-         it is cheap) rather than being treated as an extra, skippable
-         step.
+         the oracles at all, so it MUST stay in `all`, `ci`, and `fast`
+         (since it is cheap) rather than being treated as an extra,
+         skippable step.
   build  Run go build ./... in every Go module.
   contract
          Validate the job contract tree and, when DEV_HEALTH_CONTRACT_BASE is
@@ -46,7 +46,7 @@ usage() {
   multi-replica-workers
          Run the production ops-profile multi-replica claim, drain, and restart
          gate against real PostgreSQL with `-count=1`. Requires a non-zero
-         measured-job proof artifact. Included in `fast` and `all`.
+         measured-job proof artifact. Included in `fast`, `ci`, and `all`.
   integration-vet
          Compile-check every package under the integration build tag, across
          the WHOLE tree. No Docker required. This is what would have caught a
@@ -78,9 +78,24 @@ usage() {
          real containers, except the (small, justified) INTEGRATION_DENYLIST.
          Inclusion is the default; exclusion is the explicit, loud exception.
   fast   Run fmt, vet, test, live-python-oracles, build, contract,
-         integration-vet, and the integration shard-plan checks.
+         integration-vet, and the integration shard-plan checks (PLAN only --
+         does not execute the integration suite; see `ci`, `all`, and
+         `integration`). No race detector -- the quick local-iteration mode.
+  ci     Exactly `fast` plus the race detector (CHAOS-3948): fmt, vet, test,
+         race, live-python-oracles, build, contract, integration-vet, and the
+         integration shard-plan checks (PLAN only, same as `fast`), plus
+         multi-replica-workers. This is byte-for-byte what `all` ran before
+         CHAOS-3948 -- go.yml'\''s go-quality step uses this so its coverage
+         stays unchanged. CI gets its real (sharded, parallel) integration
+         signal from the separate go-storage-integration-plan/-shard jobs,
+         not from this step.
   all    Run fmt, vet, test, race, live-python-oracles, build, contract,
-         integration-vet, and the integration shard-plan checks (default).'
+         integration-vet, the FULL integration suite (every non-denylisted
+         package, unsharded -- Docker required), and multi-replica-workers
+         (default). This is slower than `ci`: expect several more minutes on
+         top of the unit/race suites (measured ~24m for the integration
+         suite alone), and Docker running locally. The honest local pre-push
+         signal `ci` cannot be, since `ci` stays PLAN-only by design.'
 }
 
 die() {
@@ -1246,7 +1261,16 @@ case "${1:-all}" in
     plan_providersync_test_shards
     check_multi_replica_workers
     ;;
-  all)
+  ci)
+    # Exactly the pre-CHAOS-3948 `all` behaviour: everything `all` runs
+    # except the full unsharded integration suite, which stays PLAN-only
+    # here on purpose. CI's go-storage-integration-plan/-shard jobs already
+    # run that suite for real, sharded and parallel, with their own timeout
+    # budget per shard -- running it again here, unsharded, would duplicate
+    # that work and blow this job's timeout (measured ~24m for `all`'s
+    # check_integration alone vs this job's 20m budget). `ci` exists so
+    # go.yml's go-quality step keeps byte-for-byte the coverage it always
+    # had, while `all` becomes the honest full-signal verb for local use.
     check_format
     check_vet
     check_test
@@ -1257,6 +1281,18 @@ case "${1:-all}" in
     check_integration_vet
     plan_integration_shards
     plan_providersync_test_shards
+    check_multi_replica_workers
+    ;;
+  all)
+    check_format
+    check_vet
+    check_test
+    check_race
+    check_live_python_oracles
+    check_build
+    check_contract
+    check_integration_vet
+    check_integration
     check_multi_replica_workers
     ;;
   -h|--help|help)

--- a/internal/syncroute/fence_integration_test.go
+++ b/internal/syncroute/fence_integration_test.go
@@ -1,0 +1,131 @@
+//go:build integration
+
+package syncroute
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// startFenceSchemaPostgres starts a real Postgres testcontainer and creates
+// the sync_dispatch_transport_routes table Fence.Check() queries. Schema
+// shape matches src/dev_health_ops/alembic/versions/0049_add_sync_dispatch_transport_fence.py,
+// minus the columns/constraints Check() never reads -- consistent with every
+// other Postgres integration test in this repo, none of which run the real
+// migration chain against a testcontainer; they all hand-build the shape
+// their target query needs.
+func startFenceSchemaPostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("close PostgreSQL: %v", err)
+		}
+	})
+
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE public.sync_dispatch_transport_routes (
+			kind text PRIMARY KEY, transport text NOT NULL, generation bigint NOT NULL,
+			paused boolean NOT NULL, paused_at timestamptz, rollback_transport text NOT NULL,
+			updated_at timestamptz NOT NULL
+		)`); err != nil {
+		t.Fatal(err)
+	}
+	return pool
+}
+
+func insertFenceRoute(t *testing.T, ctx context.Context, pool *pgxpool.Pool, kind, transport, rollbackTransport string, generation int64) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO public.sync_dispatch_transport_routes
+			(kind, transport, generation, paused, paused_at, rollback_transport, updated_at)
+		VALUES ($1, $2, $3, FALSE, NULL, $4, NOW())`,
+		kind, transport, generation, rollbackTransport,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestFenceAgainstMigratedPostgres proves the fence's real SQL executes
+// correctly against real Postgres when persisted state matches the current
+// contract. Every other Check() test in this package (fence_test.go) drives
+// a fake routeRows, which cannot catch a query/scan mismatch the way a live
+// driver round-trip can. It seeds exactly the four frozen routes the
+// checked-in contract declares (via the same validStates helper the
+// fake-backed tests use), so a passing Check() here is evidence about the
+// query, not only the in-memory validation logic.
+//
+// This alone is non-vacuous (a broken query/scan still fails it) but cannot
+// by itself prove Check() rejects a REAL stale state, because it seeds from
+// the same registry Check() reads -- see the paired drift case below.
+//
+// CHAOS-3948: this used to live in fence_test.go gated on
+// DEV_HEALTH_POSTGRES_TEST_URI, which nothing in ci/check_go.sh or go.yml
+// ever set -- it had never executed anywhere in the automated pipeline.
+// Moved behind the integration build tag and wired to the same
+// containers.StartPostgres pattern control_integration_test.go already uses
+// in this package, now that `ci/check_go.sh all` genuinely runs integration.
+func TestFenceAgainstMigratedPostgres(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	pool := startFenceSchemaPostgres(t, ctx)
+
+	registry := loadRegistry(t)
+	for _, state := range validStates(registry) {
+		insertFenceRoute(t, ctx, pool, state.kind, state.transport, state.rollbackTransport, state.generation)
+	}
+
+	fence, err := New(pool, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fence.Check(ctx); err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+}
+
+// TestFenceDetectsDriftAgainstTheOriginalMigrationBaseline is the paired
+// negative case codex adversarial review asked for: the healthy case above
+// seeds from the same registry Check() validates against, so on its own it
+// cannot prove Check() rejects a genuinely stale persisted state -- it would
+// pass even if Check()'s comparison were a no-op. This seeds the table with
+// migration 0049's real original bulk_insert values (every kind on
+// 'celery', generation 1, unpaused -- see
+// src/dev_health_ops/alembic/versions/0049_add_sync_dispatch_transport_fence.py:63-78),
+// which the current contract (contracts/sync-dispatch/v1/transport-routes.json)
+// has since moved to 'river' for. A real database that was migrated but
+// never cut over must fail Check() with ErrDrift.
+func TestFenceDetectsDriftAgainstTheOriginalMigrationBaseline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	pool := startFenceSchemaPostgres(t, ctx)
+
+	registry := loadRegistry(t)
+	for _, kind := range frozenKinds {
+		insertFenceRoute(t, ctx, pool, kind, "celery", "celery", 1)
+	}
+
+	fence, err := New(pool, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fence.Check(ctx); !errors.Is(err, ErrDrift) {
+		t.Fatalf("Check() error = %v, want ErrDrift", err)
+	}
+}

--- a/internal/syncroute/fence_test.go
+++ b/internal/syncroute/fence_test.go
@@ -3,14 +3,12 @@ package syncroute
 import (
 	"context"
 	"errors"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func TestFenceChecksCompleteActiveRouteSetWithOneBoundedQuery(t *testing.T) {
@@ -119,25 +117,6 @@ func TestNewRequiresDomainPoolAndFrozenRegistry(t *testing.T) {
 	}
 	if _, err := newFence(nil, func(context.Context) (routeRows, error) { return nil, nil }); !errors.Is(err, ErrInvalidConfiguration) {
 		t.Fatalf("newFence(nil, query) error = %v", err)
-	}
-}
-
-func TestFenceAgainstMigratedPostgres(t *testing.T) {
-	databaseURI := os.Getenv("DEV_HEALTH_POSTGRES_TEST_URI")
-	if databaseURI == "" {
-		t.Skip("DEV_HEALTH_POSTGRES_TEST_URI is not set")
-	}
-	pool, err := pgxpool.New(t.Context(), databaseURI)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(pool.Close)
-	fence, err := New(pool, loadRegistry(t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := fence.Check(t.Context()); err != nil {
-		t.Fatalf("Check() error = %v", err)
 	}
 }
 

--- a/tests/test_go_live_oracle_ci.py
+++ b/tests/test_go_live_oracle_ci.py
@@ -69,7 +69,15 @@ def test_go_quality_bootstraps_locked_live_oracle_dependencies() -> None:
     install = (
         "python -m pip install --no-deps -r ci/requirements-live-python-oracles.txt"
     )
-    quality_gate = "bash ci/check_go.sh all"
+    # CHAOS-3948: go-quality runs `ci`, not `all` -- `all` now genuinely
+    # executes the full integration suite (Docker-backed, ~24m measured),
+    # which would blow this job's timeout and duplicate the separate,
+    # already-sharded go-storage-integration-plan/-shard jobs. `ci` is
+    # byte-for-byte the pre-CHAOS-3948 `all` (see
+    # tests/tooling/test_check_go_public_verbs.py's VERB_STEPS), so it still
+    # runs check_live_python_oracles and this bootstrap assertion still
+    # holds.
+    quality_gate = "bash ci/check_go.sh ci"
     assert install in commands
     assert commands.index(install) < commands.index(quality_gate)
 

--- a/tests/tooling/test_check_go_public_verbs.py
+++ b/tests/tooling/test_check_go_public_verbs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -23,8 +24,115 @@ PUBLIC_VERBS = (
     "integration-shard",
     "integration",
     "fast",
+    "ci",
     "all",
 )
+
+# CHAOS-3948: the composite verbs' exact step sequence, keyed to what `case
+# "${1:-all}"` in ci/check_go.sh actually runs -- not just documented in
+# usage(), asserted against the live source below. `ci` exists so
+# go.yml's go-quality step keeps byte-for-byte the pre-CHAOS-3948 `all`
+# coverage while `all` itself became the honest full local signal (it now
+# runs check_integration for real instead of only planning it). The model
+# below IS the parity table: `ci` must equal `fast` plus `check_race`, and
+# `all` must equal `ci` with its two plan-only integration calls replaced by
+# one real check_integration call -- anything else is a coverage regression
+# in one verb or the other.
+_FAST_STEPS = (
+    "check_format",
+    "check_vet",
+    "check_test",
+    "check_live_python_oracles",
+    "check_build",
+    "check_contract",
+    "check_integration_vet",
+    "plan_integration_shards",
+    "plan_providersync_test_shards",
+    "check_multi_replica_workers",
+)
+_CI_STEPS = (
+    "check_format",
+    "check_vet",
+    "check_test",
+    "check_race",
+    "check_live_python_oracles",
+    "check_build",
+    "check_contract",
+    "check_integration_vet",
+    "plan_integration_shards",
+    "plan_providersync_test_shards",
+    "check_multi_replica_workers",
+)
+_ALL_STEPS = (
+    "check_format",
+    "check_vet",
+    "check_test",
+    "check_race",
+    "check_live_python_oracles",
+    "check_build",
+    "check_contract",
+    "check_integration_vet",
+    "check_integration",
+    "check_multi_replica_workers",
+)
+VERB_STEPS = {"fast": _FAST_STEPS, "ci": _CI_STEPS, "all": _ALL_STEPS}
+
+
+def _case_block_body(source: str, verb: str) -> str:
+    """The exact statement lines inside `  <verb>)` ... `    ;;` in the
+    trailing `case "${1:-all}" in ... esac` dispatcher -- not the first
+    match of the verb name anywhere in the file (a verb name can also appear
+    in a comment or an earlier function body)."""
+
+    dispatcher = source.split('case "${1:-all}" in', 1)[1]
+    match = re.search(rf"\n  {re.escape(verb)}\)\n(.*?)\n    ;;", dispatcher, re.DOTALL)
+    assert match, f"no `{verb})` case block found in the dispatcher"
+    return match.group(1)
+
+
+def _bare_call_lines(block: str) -> tuple[str, ...]:
+    """Bare 4-space-indented `identifier` statement lines -- ignores
+    comments, blank lines, and anything with arguments/braces so a stray
+    guard clause doesn't get mistaken for a step."""
+
+    return tuple(
+        stripped
+        for line in block.splitlines()
+        if line.startswith("    ")
+        and (stripped := line.strip())
+        and re.fullmatch(r"[a-z_][a-z0-9_]*", stripped)
+    )
+
+
+def test_composite_verbs_match_the_checked_in_parity_table() -> None:
+    source = (ROOT / "ci" / "check_go.sh").read_text(encoding="utf-8")
+    for verb, expected_steps in VERB_STEPS.items():
+        actual_steps = _bare_call_lines(_case_block_body(source, verb))
+        assert actual_steps == expected_steps, (
+            f"`{verb}` case block runs {actual_steps!r}, expected "
+            f"{expected_steps!r} -- update VERB_STEPS deliberately if this "
+            "verb's coverage is meant to change, don't just silence this"
+        )
+
+
+def test_ci_is_fast_plus_the_race_detector() -> None:
+    # fast was NOT an equivalent stand-in for the pre-CHAOS-3948 `all` when
+    # go.yml's go-quality step needed one: it silently drops the race
+    # detector. Pinning the relationship directly, not just each verb's own
+    # step list, so that invariant can't erode one verb at a time.
+    assert set(_CI_STEPS) - set(_FAST_STEPS) == {"check_race"}
+    assert set(_FAST_STEPS) - set(_CI_STEPS) == set()
+
+
+def test_all_is_ci_with_integration_actually_executed() -> None:
+    # `all`'s whole point (CHAOS-3948) is trading `ci`'s two plan-only calls
+    # for one call that actually runs the suite -- everything else `ci`
+    # covers must still be covered.
+    assert set(_CI_STEPS) - set(_ALL_STEPS) == {
+        "plan_integration_shards",
+        "plan_providersync_test_shards",
+    }
+    assert set(_ALL_STEPS) - set(_CI_STEPS) == {"check_integration"}
 
 
 def test_help_completes_and_documents_every_public_verb() -> None:
@@ -65,5 +173,7 @@ def test_multi_replica_gate_is_cold_measured_and_required() -> None:
     assert "-tags=integration -count=1" in function
     assert "DEV_HEALTH_MULTI_REPLICA_PROOF" in function
     assert "measured zero jobs" in function
-    # One public verb plus the required fast and all paths.
-    assert source.count("    check_multi_replica_workers\n") == 3
+    # One public verb plus the required fast, ci, and all paths (CHAOS-3948
+    # added `ci`) -- also asserted per-verb in VERB_STEPS above, but this
+    # catches a stray extra/missing call site anywhere else in the file.
+    assert source.count("    check_multi_replica_workers\n") == 4


### PR DESCRIPTION
## Summary

`ci/check_go.sh all`'s `all)` case called `plan_integration_shards` and `plan_providersync_test_shards` — both PLAN-only, printing a dry-run selection — instead of `check_integration`, which actually runs `go test -tags=integration` against real containers. So `rc=0` with the full `ok`-package count read as a complete local gate while the Docker-backed integration suite silently never executed; a change could pass locally and fail CI on an integration shard (PR 1805 / CHAOS-3936, the incident that surfaced this).

`all` now calls `check_integration` for real. This adds no new local prerequisite — `check_multi_replica_workers`, already unconditional in `all`, already required Docker — only more time (measured ~24.4m for the full 26-package suite; `internal/providersync` alone is 1462s). `fast` stays plan-only by design (its whole point is staying quick), now documented explicitly in `usage()`.

## The CI-timeout problem this exposed, and the `ci` verb

`go.yml`'s `go-quality` step called `bash ci/check_go.sh all` directly. Left as-is, that job (20-minute timeout) would have started timing out on every run, while duplicating work the separate, already-sharded `go-storage-integration-plan`/`-shard` jobs already do in parallel with their own budget — found by adversarial codex review, not by inspection.

Fix: added a `ci` verb, byte-for-byte the **pre-fix `all` behaviour** (everything `all` ran, integration suite PLAN-only), and pointed `go-quality` at it instead of `fast` — checked first that `fast` was NOT an equivalent substitute:

| step | old `all` (pre-fix) | `fast` | `ci` (new) | `all` (post-fix) |
|---|---|---|---|---|
| format/vet/test | yes | yes | yes | yes |
| race | yes | **no** | yes | yes |
| live-python-oracles | yes | yes | yes | yes |
| build/contract/integration-vet | yes | yes | yes | yes |
| integration shard plan (validation only) | yes | yes | yes | yes |
| integration suite EXECUTED | no (planned only) | no | no (planned only) | **yes (new)** |
| multi-replica-workers | yes | yes | yes | yes |

`fast` silently drops the race detector — not an equivalent stand-in. `ci` ≡ old `all` exactly, so `go-quality`'s CI coverage is unchanged; `all` becomes the honest full local pre-push signal.

## Spinoff: TestFenceAgainstMigratedPostgres (CHAOS-3448 family)

While verifying this, found a Go-side sibling of CHAOS-3448 ("a class of live-Postgres tests has never executed anywhere"): `internal/syncroute/fence_test.go`'s `TestFenceAgainstMigratedPostgres` always skipped — gated on `DEV_HEALTH_POSTGRES_TEST_URI`, which nothing in `check_go.sh` or `go.yml` ever set, so it had never executed anywhere in the automated pipeline.

Checked whether wiring it was cheap before settling for a mere note: this repo's Go integration tests don't run real migrations against testcontainers anywhere (every one hand-builds its schema), and this package already had the exact pattern needed (`control_integration_test.go`'s `containers.StartPostgres`, `fence_test.go`'s own `validStates(registry)` helper). Moved it to `internal/syncroute/fence_integration_test.go` (`//go:build integration`), wired to a real Postgres testcontainer. Confirmed passing.

Codex adversarial review then flagged that test alone as tautological — it seeds from the same registry `Check()` reads, so it can prove the SQL round-trips but not that `Check()` rejects a genuinely stale state. Added the paired negative case, `TestFenceDetectsDriftAgainstTheOriginalMigrationBaseline`: seeds the table with migration `0049_add_sync_dispatch_transport_fence.py`'s real original `celery` baseline, asserts `ErrDrift` against the current `river` contract. Both pass.

Related and commented on CHAOS-3448 (test name/file/grep proof of never-running, then a follow-up noting this instance is now resolved while the rest of that ticket's population — the 9 Python tests — is unchanged).

## Test plan

- [x] `bash -n ci/check_go.sh` and `shellcheck ci/check_go.sh` clean
- [x] Positive control: `go test -tags=integration ./internal/streamrunner/...` — real Valkey testcontainers, PASS
- [x] Negative control: synthetic `t.Fatal` integration test — FAIL, rc=1, confirms `set -euo pipefail` propagates a real integration failure as the script's exit code (file removed after, not committed)
- [x] `bash ci/check_go.sh integration` run in full: **26/26 packages ok, 0 FAIL, exit 0**, ~24.4 minutes
- [x] `bash ci/check_go.sh ci` run in full: 114 ok, exit 1 on exactly one pre-documented, pre-existing macOS-only oracle flake (`TestBuildScheduledPlanMatchesLivePythonPlanner`, jira `processor_flags` divergence — already noted in a CHAOS-3948 comment today as reproducing on clean `origin/main` locally but confirmed absent in real CI on `ubuntu-latest`; unrelated to this diff, `check_live_python_oracles` untouched)
- [x] `TestFenceAgainstMigratedPostgres` + `TestFenceDetectsDriftAgainstTheOriginalMigrationBaseline` both PASS against real Postgres testcontainers
- [x] Codex adversarial review (xhigh) — one finding fixed (tautological fence test), one finding drove the `ci` verb addition; no remaining findings

No self-merge; awaiting review.