### PR TITLE
fix(alerts): correct GoWorkerTelemetryTargetDown's job regex typo (CHAOS-3985)

### DIFF
--- a/alerts/rules.yml
+++ b/alerts/rules.yml
@@ -300,10 +300,32 @@ groups:
             The {{ $labels.pool }} PostgreSQL pool is using more than 85% of
             its configured connection budget.
 
+      # CHAOS-3985: the job regex names the deployed unit, not the shared
+      # binary/image name -- every real manifest (compose, swarm, kubernetes,
+      # helm) deploys the stream runner under a per-profile name
+      # (stream-external/stream-ingest/stream-pagerduty), never literally
+      # "stream-runner"; only the binary and container image are called that.
+      # The regex previously said stream-runner and so could never match any
+      # deployed target's job label under any topology.
+      #
+      # An absent()-based branch for "nothing is scraping this at all" was
+      # considered and deliberately dropped: this fleet is additive and
+      # default-off (Helm `goWorkers.enabled=false`, Kubernetes Deployments
+      # at `replicas: 0` -- see deploy/kubernetes/go-workers.yaml's own
+      # header comment), so a fully empty `up{job=~...}` vector is the
+      # NORMAL state whenever Go workers simply aren't enabled yet, not
+      # evidence a configured target went dark. absent() cannot tell those
+      # two conditions apart (adversarial codex review, CHAOS-3985) -- it
+      # would page on every default deployment. This alert therefore still
+      # only detects a target that scraped successfully at least once and
+      # then stopped; it structurally cannot detect "never configured to
+      # scrape in the first place" without a durable, non-metric signal for
+      # "Go workers are expected to be running right now" that doesn't yet
+      # exist. See the CHAOS-3985 ticket for the full reasoning.
       - alert: GoWorkerTelemetryTargetDown
         expr: |
           max by (job, instance) (
-            up{job=~"dev-health-go-(worker|scheduler|reconciler|stream-runner).*"}
+            up{job=~"dev-health-go-(worker|scheduler|reconciler|stream).*"}
           ) == 0
         for: 5m
         labels:

--- a/docs/operate/observe/dashboards-and-alerts.md
+++ b/docs/operate/observe/dashboards-and-alerts.md
@@ -4,8 +4,7 @@ summary: Build actionable dashboards and alerts from service objectives and reco
 content_type: task-guide
 owner: platform-operations
 source_of_truth:
-  - docs/alerting.md
-  - docs/slos.md
+  - alerts/rules.yml
 applicability: current
 lifecycle: active
 ---

--- a/docs/operate/observe/metrics-and-traces.md
+++ b/docs/operate/observe/metrics-and-traces.md
@@ -52,6 +52,8 @@ The Go foundations expose bounded Prometheus signals for:
 
 A database sample failure makes the metric unavailable. It must not be emitted as a zero. These metrics describe the coexistence foundation and do not imply that River owns production jobs.
 
+Every Go worker, scheduler, reconciler, and stream-runner process serves these on `:8080/metrics` (`internal/platform/health/server.go`). Nothing in this repository configures a Prometheus scrape target for that endpoint, in any deployment topology (Compose, Swarm, Kubernetes, or Helm) — that wiring is the operator's responsibility, same as the rest of this repo's monitoring stack (CHAOS-3985). The `alerts/rules.yml` `go_workers` rule group assumes a scrape job named `dev-health-go-(worker|scheduler|reconciler|stream).*` — whatever scrape mechanism you configure must assign job names matching that pattern, or the rules will silently never match. The Kubernetes manifest (`deploy/kubernetes/go-workers.yaml`) already provides a `dev-health-go-workers` Service with a named `metrics` port across every go-worker pod, ready for a scrape config or ServiceMonitor to target; Compose and Swarm service names do not currently carry the `dev-health-go-` prefix and need an explicit `job_name` override wherever they're scraped from.
+
 Use the checked-in `deploy/grafana/dashboards/go-workers.json` as the current dashboard example. Keep profile and route state visible so a healthy disabled process is not mistaken for an active production consumer.
 
 ## Provider and incident delivery

--- a/tests/workers/test_go_worker_alerts.py
+++ b/tests/workers/test_go_worker_alerts.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 RULES_PATH = ROOT / "alerts" / "rules.yml"
+GO_WORKERS_K8S_PATH = ROOT / "deploy" / "kubernetes" / "go-workers.yaml"
 
 
 def _go_worker_rules() -> list[dict[str, object]]:
@@ -90,6 +92,59 @@ def test_go_worker_alerts_keep_labels_low_cardinality_and_payload_free() -> None
     )
     for label in prohibited:
         assert label not in serialized
+
+
+def test_go_worker_telemetry_target_down_regex_matches_the_naming_convention_every_kubernetes_deployment_follows() -> (
+    None
+):
+    """CHAOS-3985: the job regex previously said "stream-runner", which is the
+    shared binary/image name -- no real manifest (compose, swarm, kubernetes,
+    or helm) ever deploys a unit literally named that; every one uses a
+    per-profile name (stream-external, stream-ingest, stream-pagerduty). The
+    regex could therefore never match any deployed target's job label under
+    any topology, REGARDLESS of what an operator's scrape config assigns as
+    the job name (adversarial codex review, CHAOS-3985): this test checks
+    the regex against Kubernetes Deployment *names*, which are evidence of
+    the naming convention the regex is meant to track, not proof of what
+    Prometheus's `job` label will actually be in production -- nothing in
+    this repo configures scraping, so no test here can prove that. It pins
+    the regex-vs-naming-convention typo fix and nothing stronger.
+    """
+    rules = _go_worker_rules()
+    alerts = {str(rule["alert"]): str(rule["expr"]) for rule in rules}
+    match = re.search(r'job=~"([^"]+)"', alerts["GoWorkerTelemetryTargetDown"])
+    assert match, "GoWorkerTelemetryTargetDown must filter on a job regex"
+    job_pattern = re.compile(match.group(1))
+
+    documents = list(
+        yaml.safe_load_all(GO_WORKERS_K8S_PATH.read_text(encoding="utf-8"))
+    )
+    deployment_names = [
+        document["metadata"]["name"]
+        for document in documents
+        if document
+        and document.get("kind") == "Deployment"
+        and document.get("metadata", {})
+        .get("labels", {})
+        .get("app.kubernetes.io/component")
+        == "go-worker"
+    ]
+    # Exact, not a loose lower bound: a Deployment silently losing its
+    # go-worker label or being removed must fail this test, not slip under
+    # a loose ">=".
+    assert len(deployment_names) == 9, (
+        "expected exactly the 9 go-worker Deployments this manifest "
+        f"currently declares; found {deployment_names!r} -- update this "
+        "count deliberately if the manifest's shape changed"
+    )
+    unmatched = [name for name in deployment_names if not job_pattern.fullmatch(name)]
+    assert not unmatched, (
+        f"GoWorkerTelemetryTargetDown's job regex {job_pattern.pattern!r} does "
+        f"not match deployed unit name(s) {unmatched!r} in "
+        f"{GO_WORKERS_K8S_PATH.relative_to(ROOT)} -- an operator following "
+        "this naming convention for their scrape job names would have "
+        "targets this alert can never see"
+    )
 
 
 def test_alert_names_are_unique_across_rule_file() -> None:


### PR DESCRIPTION
## Summary

CHAOS-3985 asked whether the `go_workers` Prometheus alert group is actually scraped anywhere. Confirmed by exhaustive grep: no `scrape_configs`, `ServiceMonitor`, `PodMonitor`, or `prometheus.io/*` annotation exists anywhere in this repo across all four deployment topologies (Compose, Swarm, Kubernetes, Helm). This matches `.github/docs-legacy/alerting.md`'s deliberate, repo-wide design ("configure alert rules in your visualization platform") — not something specific to go_workers.

**This is not the same claim as "nothing scrapes production."** The prod host runs its own untracked compose stack, and the capture stack for traces is confirmed live there (CHAOS-3993) — Prometheus may already be configured on the host, outside this repo. This PR doesn't touch any deploy manifest and doesn't assert an absence it can't see.

## What's actually fixed here (alerts/rules.yml + tests + docs, zero deploy risk)

**`GoWorkerTelemetryTargetDown`'s job regex said `stream-runner`** — the shared binary/image name (`ghcr.io/full-chaos/dev-health-go-stream-runner`). No real deployed unit is ever named that in any topology; every manifest (compose, swarm, kubernetes, helm) deploys the stream runner under a per-profile name: `stream-external`, `stream-ingest`, `stream-pagerduty`. So the regex could never match any deployed stream-runner target's job label, under any topology, regardless of whether scraping is configured. Fixed: `stream-runner` → `stream`.

Verified with a negative-controlled regression test against `deploy/kubernetes/go-workers.yaml`'s real Deployment names: reverted to the old value, confirmed the test fails; restored, confirmed it passes.

## Considered and rejected: an `absent()` branch for "never scraped at all"

`up{job=~...} == 0` is an empty vector, not a `0`, when the job was never scraped — so as originally written, the one alert whose job is to catch "nothing is scraping this" can only fire on a target that scraped successfully once and then went dark, never on "never configured to begin with." I initially added `or absent(up{job=~...})` to close that gap.

**Adversarial codex review caught this was wrong before it reached anyone's pager.** The go-worker fleet is additive and default-off *by design* — Helm `goWorkers.enabled=false`, Kubernetes Deployments at `replicas: 0` (see `deploy/kubernetes/go-workers.yaml`'s own header comment). A fully-empty `up` vector is the **normal** state whenever go-workers simply aren't enabled yet, not evidence a configured target went dark. `absent()` can't tell those two conditions apart — it would have paged on every default deployment. Reverted; left the reasoning in a `rules.yml` comment so this doesn't get silently re-attempted later without re-deriving the same problem. This alert's blind spot to "never configured to scrape" stands — closing it needs a durable, non-metric signal for "go-workers are expected to be running right now," not a PromQL trick.

## The naming contract (for whoever verifies or configures the host's scrape config)

| topology | deployed unit names | matches the corrected regex? |
|---|---|---|
| Kubernetes | `dev-health-go-worker-{heavy,ops,sync,sync-provider}`, `dev-health-go-reconciler`, `dev-health-go-scheduler`, `dev-health-go-stream-{external,ingest,pagerduty}` | yes, as-is |
| Compose / Swarm | `go-worker-{heavy,ops,sync,sync-provider}`, `go-reconciler`, `go-scheduler`, `go-stream-{external,ingest,pagerduty}` | **no** — missing the `dev-health-` prefix; needs an explicit `job_name` override wherever scraped |

Bonus: `deploy/kubernetes/go-workers.yaml` already declares a `dev-health-go-workers` Service selecting every go-worker pod with a named `metrics` port (8080) — the exact object a ServiceMonitor/PodMonitor or a `kubernetes_sd_configs` scrape entry would target. Unused today; needs no new manifest, just the scrape-side config wherever that lives.

## Also fixed

- `worker_daily_metrics_lease_total` (CHAOS-3991, unmerged) traced to the same shared `MetricsCollector` → `/metrics:8080` path as everything else here — same gap applies, not a special case, not yet referenced by any alert rule.
- Dead doc reference: `docs/operate/observe/dashboards-and-alerts.md`'s frontmatter cited `docs/alerting.md`/`docs/slos.md`, neither of which exists outside the inert `docs-legacy` corpus (and the legacy `slos.md` is factually stale — pre-Go-cutover Celery-only metric names). Repointed `source_of_truth` to `alerts/rules.yml` instead of resurrecting stale content.
- Added a paragraph to `docs/operate/observe/metrics-and-traces.md` naming the job convention above and the unused k8s Service.

## Test plan

- [x] `python3 scripts/check_docs_links.py` clean
- [x] `ruff check` / `ruff format --check` / `mypy` clean on the changed test file
- [x] New regression test parses `deploy/kubernetes/go-workers.yaml`'s real 9 Deployment names, asserts every one matches the corrected regex — negative-controlled (reverted to `stream-runner`, confirmed FAIL; restored, confirmed PASS)
- [x] Full `tests/workers/test_go_worker_alerts.py`: 6/6 pass
- [x] Codex adversarial review (xhigh, two rounds): round 1 caught the `absent()` false-page risk and a loose `>=7` count — both fixed; round 1's positive findings (regex fix correctness, doc reference fix, docs paragraph accuracy) confirmed sound

No self-merge; awaiting review.