### PR TITLE
feat(observability): record lost releases in workgraph and remaining (CHAOS-4002)

### DIFF
--- a/cmd/dev-health-worker/daily.go
+++ b/cmd/dev-health-worker/daily.go
@@ -165,7 +165,14 @@ func buildDailyWorker(
 	}
 
 	if len(remainingSpecs) > 0 {
-		store, storeErr := remaining.NewPostgresStore(postgresDatabase.pools.Domain)
+		// The remaining-metrics store reports a release-lost lease directly, the
+		// same way the daily store does above (CHAOS-4002): generic middleware
+		// cannot tell that outcome apart from an ordinary release.
+		var remainingLeaseObservers []jobruntime.RemainingMetricsLeaseObserver
+		if leaseObserver, ok := observer.(jobruntime.RemainingMetricsLeaseObserver); ok {
+			remainingLeaseObservers = append(remainingLeaseObservers, leaseObserver)
+		}
+		store, storeErr := remaining.NewPostgresStore(postgresDatabase.pools.Domain, remainingLeaseObservers...)
 		compatibility, compatibilityErr := remaining.NewHTTPCompatibilityExecutor(
 			metricCompatibilityHTTPClient(cfg.OperationalBridgeTimeout),
 			remaining.HTTPCompatibilityConfig{

--- a/cmd/dev-health-worker/workgraph.go
+++ b/cmd/dev-health-worker/workgraph.go
@@ -38,7 +38,15 @@ func buildWorkgraphWorker(cfg config.Config, database workerDatabase, registry *
 	if !ok || postgresDatabase.pools == nil || observer == nil || logger == nil {
 		return workerFamily{}, errWorkerDependencyUnavailable
 	}
-	store, err := workgraph.NewPostgresStore(postgresDatabase.pools.Domain)
+	// The work-graph store reports a release-lost lease directly: generic
+	// middleware cannot tell that outcome apart from an ordinary release, and
+	// only the store that ran the fenced UPDATE knows it matched zero rows
+	// because the lease had already expired (CHAOS-4002).
+	var leaseObservers []jobruntime.WorkGraphLeaseObserver
+	if leaseObserver, ok := observer.(jobruntime.WorkGraphLeaseObserver); ok {
+		leaseObservers = append(leaseObservers, leaseObserver)
+	}
+	store, err := workgraph.NewPostgresStore(postgresDatabase.pools.Domain, leaseObservers...)
 	if err != nil {
 		return workerFamily{}, errWorkerDependencyUnavailable
 	}

--- a/internal/jobruntime/observer.go
+++ b/internal/jobruntime/observer.go
@@ -64,6 +64,22 @@ type ReportRunLeaseObserver interface {
 	ObserveReportRunLeaseExpired(ReportRunLeaseResult) error
 }
 
+// WorkGraphLeaseObserver is the narrow capability the work-graph store depends
+// on after a release is fenced out by a lease the claimant has already
+// outlived (CHAOS-4002, symmetric with DailyMetricsLeaseObserver's
+// release_lost result). Generic runtime middleware cannot infer this from a
+// job retry: only the store that ran the fenced UPDATE knows whether it
+// matched zero rows because the lease had already expired.
+type WorkGraphLeaseObserver interface {
+	ObserveWorkGraphLeaseReleaseLost() error
+}
+
+// RemainingMetricsLeaseObserver is the remaining-metrics store's equivalent of
+// WorkGraphLeaseObserver, for the same reason (CHAOS-4002).
+type RemainingMetricsLeaseObserver interface {
+	ObserveRemainingMetricsLeaseReleaseLost() error
+}
+
 // DailyMetricsLeaseObserver is the narrow capability the daily-metrics store
 // depends on after it resolves an existing lease durably. Generic runtime
 // middleware cannot infer this: a claim that parks for a live lease and a claim

--- a/internal/jobruntime/telemetry.go
+++ b/internal/jobruntime/telemetry.go
@@ -217,6 +217,8 @@ type MetricsCollector struct {
 	syncLeaseExpired      map[syncLeaseResultLabels]uint64
 	reportRunLeaseExpired map[ReportRunLeaseResult]uint64
 	dailyMetricsLease     map[dailyMetricsLeaseLabels]uint64
+	workGraphReleaseLost  uint64
+	remainingReleaseLost  uint64
 
 	streamLag                 map[StreamLabels]int64
 	streamPending             map[StreamLabels]int64
@@ -234,6 +236,8 @@ var _ Observer = (*MetricsCollector)(nil)
 var _ SyncLeaseObserver = (*MetricsCollector)(nil)
 var _ ReportRunLeaseObserver = (*MetricsCollector)(nil)
 var _ DailyMetricsLeaseObserver = (*MetricsCollector)(nil)
+var _ WorkGraphLeaseObserver = (*MetricsCollector)(nil)
+var _ RemainingMetricsLeaseObserver = (*MetricsCollector)(nil)
 
 func NewMetricsCollector(dimensions MetricDimensions) (*MetricsCollector, error) {
 	if len(dimensions.Jobs) > maxMetricJobs {
@@ -581,6 +585,26 @@ func (collector *MetricsCollector) ObserveDailyMetricsLease(
 	return nil
 }
 
+// ObserveWorkGraphLeaseReleaseLost records a work-graph claimant that could not
+// stand its own row down because its lease had already expired (CHAOS-4002).
+// Unlike the daily-metrics lease, work-graph has one lease-fenced release path
+// shared by all five kinds, so there is no stage dimension to record.
+func (collector *MetricsCollector) ObserveWorkGraphLeaseReleaseLost() error {
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+	collector.workGraphReleaseLost++
+	return nil
+}
+
+// ObserveRemainingMetricsLeaseReleaseLost is ObserveWorkGraphLeaseReleaseLost's
+// remaining-metrics equivalent (CHAOS-4002).
+func (collector *MetricsCollector) ObserveRemainingMetricsLeaseReleaseLost() error {
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+	collector.remainingReleaseLost++
+	return nil
+}
+
 func (collector *MetricsCollector) SetExecutionSaturation(queue string, ratio float64) error {
 	if math.IsNaN(ratio) || math.IsInf(ratio, 0) || ratio < 0 || ratio > 1 {
 		return errors.New("execution saturation must be between zero and one")
@@ -740,6 +764,8 @@ func (collector *MetricsCollector) PrometheusText() string {
 	collector.writeSyncLeases(&output)
 	collector.writeReportRunLeases(&output)
 	collector.writeDailyMetricsLeases(&output)
+	collector.writeWorkGraphLease(&output)
+	collector.writeRemainingMetricsLease(&output)
 	collector.writeStreams(&output)
 	collector.writeBudgets(&output)
 	collector.writeConcurrencyBudgets(&output)
@@ -901,6 +927,16 @@ func (collector *MetricsCollector) writeDailyMetricsLeases(output *strings.Build
 			{"stage", string(labels.Stage)}, {"result", string(labels.Result)},
 		}, collector.dailyMetricsLease[labels])
 	}
+}
+
+func (collector *MetricsCollector) writeWorkGraphLease(output *strings.Builder) {
+	writeMetadata(output, "worker_workgraph_lease_release_lost_total", "Work-graph releases that found their own lease already expired.", "counter")
+	writeUintSample(output, "worker_workgraph_lease_release_lost_total", nil, collector.workGraphReleaseLost)
+}
+
+func (collector *MetricsCollector) writeRemainingMetricsLease(output *strings.Builder) {
+	writeMetadata(output, "worker_remaining_metrics_lease_release_lost_total", "Remaining-metrics releases that found their own lease already expired.", "counter")
+	writeUintSample(output, "worker_remaining_metrics_lease_release_lost_total", nil, collector.remainingReleaseLost)
 }
 
 func (collector *MetricsCollector) writeBudgets(output *strings.Builder) {

--- a/internal/jobruntime/telemetry_test.go
+++ b/internal/jobruntime/telemetry_test.go
@@ -59,6 +59,11 @@ func TestMetricsCollectorEmitsDeterministicLowCardinalityPrometheusText(t *testi
 	if err := collector.ObserveReportRunLeaseExpired(ReportRunLeaseResultRetrying); err != nil {
 		t.Fatal(err)
 	}
+	if err := collector.ObserveWorkGraphLeaseReleaseLost(); err != nil {
+		t.Fatal(err)
+	}
+	// RemainingMetricsLeaseReleaseLost is deliberately left unobserved so its
+	// pre-seeded zero (asserted below) is proven, not merely assumed.
 
 	if err := collector.SetStreamLag(stream, 19); err != nil {
 		t.Fatal(err)
@@ -112,6 +117,8 @@ func TestMetricsCollectorEmitsDeterministicLowCardinalityPrometheusText(t *testi
 		`worker_daily_metrics_lease_total{stage="partition",result="reclaimed"} 0`,
 		`worker_daily_metrics_lease_total{stage="partition",result="release_lost"} 0`,
 		`worker_daily_metrics_lease_total{stage="partition",result="snoozed"} 0`,
+		`worker_workgraph_lease_release_lost_total 1`,
+		`worker_remaining_metrics_lease_release_lost_total 0`,
 		`worker_stream_lag{stream="external_ingest",consumer_group="sink_workers"} 19`,
 		`worker_stream_pending{stream="external_ingest",consumer_group="sink_workers"} 3`,
 		`worker_stream_oldest_pending_seconds{stream="external_ingest",consumer_group="sink_workers"} 8`,
@@ -133,6 +140,7 @@ func TestMetricsCollectorEmitsDeterministicLowCardinalityPrometheusText(t *testi
 		"worker_job_attempts_total", "worker_job_panics_total", "worker_job_cancellations_total",
 		"worker_domain_state_mismatch_total", "worker_sync_lease_expired_total", "worker_report_run_lease_expired_total",
 		"worker_daily_metrics_lease_total",
+		"worker_workgraph_lease_release_lost_total", "worker_remaining_metrics_lease_release_lost_total",
 		"worker_stream_lag", "worker_stream_pending",
 		"worker_stream_oldest_pending_seconds", "worker_budget_wait_seconds",
 		"worker_database_pool_saturation_ratio", "worker_database_pool_acquire_seconds",

--- a/internal/jobs/metrics/remaining/handler_test.go
+++ b/internal/jobs/metrics/remaining/handler_test.go
@@ -64,6 +64,28 @@ func TestPartitionHandlerRenewsAndCompletesWithBoundedEvidence(t *testing.T) {
 	}
 }
 
+// CHAOS-4002: handler.go has a third releaseClaim discard site (LoadRun
+// failure) that TestPartitionHandlerRejectsCrossFamilyExecution (validation
+// mismatch) and TestPartitionHandlerLeaseLossCancelsCompatibility (lease loss
+// during work) do not exercise -- this was the one release site with no
+// existing coverage at all before this ticket.
+func TestPartitionHandlerReleasesClaimOnLoadRunFailure(t *testing.T) {
+	store := &handlerStore{
+		claim:      handlerClaim(),
+		loadRunErr: ErrUnavailable,
+	}
+	handler, err := NewPartitionHandler[jobruntime.RemainingCapacityArgs](
+		store, &handlerCompatibility{}, "capacity",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = handler.Work(t.Context(), capacityExecution())
+	if err == nil || store.releases != 1 || store.completions != 0 {
+		t.Fatalf("LoadRun failure error=%v releases=%d completions=%d", err, store.releases, store.completions)
+	}
+}
+
 func TestPartitionHandlerLeaseLossCancelsCompatibility(t *testing.T) {
 	store := &handlerStore{
 		run: Run{
@@ -126,12 +148,16 @@ type handlerStore struct {
 	claim       *Claim
 	renewals    int
 	failRenewal bool
+	loadRunErr  error
 	releases    int
 	completions int
 	evidence    string
 }
 
 func (store *handlerStore) LoadRun(context.Context, string) (Run, error) {
+	if store.loadRunErr != nil {
+		return Run{}, store.loadRunErr
+	}
 	return store.run, nil
 }
 func (store *handlerStore) ClaimPartition(context.Context, string) (*Claim, error) {

--- a/internal/jobs/metrics/remaining/lease_release_lost_integration_test.go
+++ b/internal/jobs/metrics/remaining/lease_release_lost_integration_test.go
@@ -1,0 +1,213 @@
+//go:build integration
+
+package remaining
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// recordingRemainingLeaseObserver counts exactly what the production counter
+// counts, so the test predicts the metric rather than merely proving
+// ReleasePartition returned the expected error.
+type recordingRemainingLeaseObserver struct{ releaseLost int }
+
+func (observer *recordingRemainingLeaseObserver) ObserveRemainingMetricsLeaseReleaseLost() error {
+	observer.releaseLost++
+	return nil
+}
+
+// TestReleasePartitionRecordsReleaseLostOnlyOnAnExpiredLease is the
+// CHAOS-4002 mutation-catching test: dropping the observeReleaseLost() call
+// in ReleasePartition must fail this. Both directions are seeded (input
+// symmetry): a live-lease release that succeeds must NOT record anything, and
+// an expired-lease release that fails with ErrLeaseLost MUST record exactly
+// once. A second pass through the SAME scenario using a real
+// jobruntime.MetricsCollector (TestReleasePartitionRecordsReleaseLostInRealPrometheusExposition,
+// below) additionally proves the PrometheusText wiring itself, which a
+// bespoke recorder like the one used here cannot: it would keep passing even
+// if writeRemainingMetricsLease were dropped from PrometheusText entirely.
+//
+// Unlike work-graph's Ambiguous (a terminal transition), ReleasePartition
+// sets status='failed', which ClaimPartition's own WHERE clause still
+// accepts -- so the SAME partition is reclaimed for the second half of the
+// test, proving the release genuinely returned it to the pool rather than
+// merely returning a distinguishable error.
+//
+// handler.go has three releaseClaim discard sites (LoadRun error, validation
+// mismatch, lease loss during work); all three fire either synchronously
+// right after ClaimPartition or after runWithLeaseRenewal's own failure,
+// with no time gap in which THIS claimant's lease genuinely expires before
+// its own release attempt, so the only way any of them meets an
+// already-expired lease in production is a real concurrent reclaim racing in
+// between, not something a mocked clock can reproduce honestly. That all
+// three sites reach ReleasePartition at all is pinned, unchanged by this
+// ticket except for adding the one case that had no coverage before it
+// (LoadRun error): TestPartitionHandlerRejectsCrossFamilyExecution
+// (validation mismatch), TestPartitionHandlerLeaseLossCancelsCompatibility
+// (lease loss), and TestPartitionHandlerReleasesClaimOnLoadRunFailure
+// (LoadRun error, added by this ticket) in handler_test.go. What this test
+// adds is what ReleasePartition itself does once reached: recording is
+// centralized in the store, not duplicated per call site, so proving it here
+// covers every caller by construction.
+func TestReleasePartitionRecordsReleaseLostOnlyOnAnExpiredLease(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer instance.Close(context.Background())
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createRemainingTables(t, ctx, pool)
+
+	observer := &recordingRemainingLeaseObserver{}
+	store, err := NewPostgresStore(pool, observer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	run, err := store.StartRun(ctx, StartRunRequest{
+		OrganizationID: "00000000-0000-4000-8000-000000000110",
+		Family:         "capacity",
+		Generation:     "release-lost-fixture",
+		ScopeKey:       "all-teams",
+		GenerationSeed: int64Pointer(7),
+		Scopes:         []json.RawMessage{json.RawMessage(`{"version":1,"all_teams":true,"history_days":90,"simulations":10000}`)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	partitionID := deterministicPartitionID(run.ID, 1)
+
+	// Still within the lease: ReleasePartition succeeds and must not record
+	// release_lost -- a claimant that still holds its lease standing its own
+	// row down deliberately is not a stall signal.
+	liveClaim, err := store.ClaimPartition(ctx, partitionID)
+	if err != nil || liveClaim == nil {
+		t.Fatalf("live claim = %#v, %v", liveClaim, err)
+	}
+	if err := store.ReleasePartition(ctx, *liveClaim); err != nil {
+		t.Fatalf("live-lease ReleasePartition = %v", err)
+	}
+	if observer.releaseLost != 0 {
+		t.Fatalf("live-lease release-lost count = %d, want 0", observer.releaseLost)
+	}
+
+	// Reclaim the same partition (status='failed' is still claimable), then
+	// let its lease expire before attempting to release it -- the exact
+	// CHAOS-3991 shape: the claimant has outlived its own lease and can no
+	// longer stand its row down.
+	expiredClaim, err := store.ClaimPartition(ctx, partitionID)
+	if err != nil || expiredClaim == nil {
+		t.Fatalf("expired-lease claim = %#v, %v", expiredClaim, err)
+	}
+	var preReleaseToken string
+	var preReleaseLeaseExpiry time.Time
+	if err := pool.QueryRow(ctx, `SELECT claim_token::text, lease_expires_at FROM remaining_metric_partitions WHERE id = $1::uuid`, partitionID).Scan(&preReleaseToken, &preReleaseLeaseExpiry); err != nil {
+		t.Fatal(err)
+	}
+
+	now = now.Add(store.lease + time.Second)
+	err = store.ReleasePartition(ctx, *expiredClaim)
+	if !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("expired-lease ReleasePartition = %v, want ErrLeaseLost", err)
+	}
+	if observer.releaseLost != 1 {
+		t.Fatalf("expired-lease release-lost count = %d, want 1", observer.releaseLost)
+	}
+
+	// The fence itself must be unchanged by the lost release: the row stays
+	// exactly as the expired claimant left it -- status, claim_token, AND
+	// lease_expires_at -- for a live claimant to reclaim. A regression that
+	// clears the token or lease while leaving status alone would only be
+	// caught by checking all three.
+	var status, postReleaseToken string
+	var postReleaseLeaseExpiry time.Time
+	if err := pool.QueryRow(ctx, `SELECT status, claim_token::text, lease_expires_at FROM remaining_metric_partitions WHERE id = $1::uuid`, partitionID).Scan(&status, &postReleaseToken, &postReleaseLeaseExpiry); err != nil {
+		t.Fatal(err)
+	}
+	if status != "running" {
+		t.Fatalf("expired-lease partition status = %q, want unchanged 'running'", status)
+	}
+	if postReleaseToken != preReleaseToken {
+		t.Fatalf("expired-lease claim_token = %q, want unchanged %q", postReleaseToken, preReleaseToken)
+	}
+	if !postReleaseLeaseExpiry.Equal(preReleaseLeaseExpiry) {
+		t.Fatalf("expired-lease lease_expires_at = %v, want unchanged %v", postReleaseLeaseExpiry, preReleaseLeaseExpiry)
+	}
+}
+
+// TestReleasePartitionRecordsReleaseLostInRealPrometheusExposition proves the
+// full production wiring end to end: a real jobruntime.MetricsCollector, not
+// a bespoke recorder, so this fails if writeRemainingMetricsLease is ever
+// dropped from PrometheusText -- a gap the bespoke-recorder test above cannot
+// see (adversarial codex review, CHAOS-4002).
+func TestReleasePartitionRecordsReleaseLostInRealPrometheusExposition(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer instance.Close(context.Background())
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createRemainingTables(t, ctx, pool)
+
+	collector, err := jobruntime.NewMetricsCollector(jobruntime.MetricDimensions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(collector.PrometheusText(), "worker_remaining_metrics_lease_release_lost_total 0\n") {
+		t.Fatal("collector did not pre-seed worker_remaining_metrics_lease_release_lost_total at 0")
+	}
+
+	store, err := NewPostgresStore(pool, collector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	run, err := store.StartRun(ctx, StartRunRequest{
+		OrganizationID: "00000000-0000-4000-8000-000000000111",
+		Family:         "capacity",
+		Generation:     "release-lost-prometheus-fixture",
+		ScopeKey:       "all-teams",
+		GenerationSeed: int64Pointer(11),
+		Scopes:         []json.RawMessage{json.RawMessage(`{"version":1,"all_teams":true,"history_days":90,"simulations":10000}`)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	partitionID := deterministicPartitionID(run.ID, 1)
+	claim, err := store.ClaimPartition(ctx, partitionID)
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, %v", claim, err)
+	}
+	now = now.Add(store.lease + time.Second)
+	if err := store.ReleasePartition(ctx, *claim); !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("ReleasePartition = %v, want ErrLeaseLost", err)
+	}
+	if !strings.Contains(collector.PrometheusText(), "worker_remaining_metrics_lease_release_lost_total 1\n") {
+		t.Fatalf("PrometheusText did not reflect the release-lost observation:\n%s", collector.PrometheusText())
+	}
+}

--- a/internal/jobs/metrics/remaining/postgres.go
+++ b/internal/jobs/metrics/remaining/postgres.go
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/full-chaos/dev-health-ops/internal/joboutbox"
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -86,20 +87,37 @@ type Claim struct {
 }
 
 type PostgresStore struct {
-	pool  *pgxpool.Pool
-	lease time.Duration
-	now   func() time.Time
+	pool          *pgxpool.Pool
+	lease         time.Duration
+	now           func() time.Time
+	leaseObserver jobruntime.RemainingMetricsLeaseObserver
 }
 
 type PartitionPublisher interface {
 	PublishPartitionTx(context.Context, pgx.Tx, Run, Partition, string) error
 }
 
-func NewPostgresStore(pool *pgxpool.Pool) (*PostgresStore, error) {
+// observeReleaseLost records a durably resolved release-lost outcome. Metric
+// failures are dropped: telemetry must never decide whether a run can make
+// progress.
+func (store *PostgresStore) observeReleaseLost() {
+	if store.leaseObserver != nil {
+		_ = store.leaseObserver.ObserveRemainingMetricsLeaseReleaseLost()
+	}
+}
+
+func NewPostgresStore(
+	pool *pgxpool.Pool,
+	observers ...jobruntime.RemainingMetricsLeaseObserver,
+) (*PostgresStore, error) {
 	if pool == nil {
 		return nil, ErrUnavailable
 	}
-	return &PostgresStore{pool: pool, lease: defaultLease, now: time.Now}, nil
+	var observer jobruntime.RemainingMetricsLeaseObserver
+	if len(observers) > 0 {
+		observer = observers[0]
+	}
+	return &PostgresStore{pool: pool, lease: defaultLease, now: time.Now, leaseObserver: observer}, nil
 }
 
 // StartRun atomically persists a deterministic generation and every partition
@@ -434,6 +452,10 @@ WHERE run.id = $2::uuid AND run.status = 'running'
 	return nil
 }
 
+// ReleasePartition stands a claimed partition back down. Release is fenced on
+// a live lease, so a claimant that has already outlived its lease cannot
+// release it; that outcome is recorded rather than left for the caller to
+// discard (CHAOS-4002).
 func (store *PostgresStore) ReleasePartition(ctx context.Context, claim Claim) error {
 	if !store.validClaim(claim) {
 		return ErrUnavailable
@@ -452,6 +474,7 @@ WHERE id = $2::uuid AND run_id = $3::uuid AND status = 'running'
 		return ErrUnavailable
 	}
 	if command.RowsAffected() != 1 {
+		store.observeReleaseLost()
 		return ErrLeaseLost
 	}
 	return nil

--- a/internal/jobs/workgraph/lease_release_lost_integration_test.go
+++ b/internal/jobs/workgraph/lease_release_lost_integration_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package workgraph
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// recordingWorkGraphLeaseObserver counts exactly what the production counter
+// counts, so the test predicts the metric rather than merely proving Ambiguous
+// returned the expected error.
+type recordingWorkGraphLeaseObserver struct{ releaseLost int }
+
+func (observer *recordingWorkGraphLeaseObserver) ObserveWorkGraphLeaseReleaseLost() error {
+	observer.releaseLost++
+	return nil
+}
+
+func startWorkGraphReleaseLostFixture(
+	t *testing.T, ctx context.Context,
+) (*pgxpool.Pool, *PostgresStore, *recordingWorkGraphLeaseObserver) {
+	t.Helper()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { instance.Close(context.Background()) })
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	createExecutionTables(t, ctx, pool)
+	observer := &recordingWorkGraphLeaseObserver{}
+	store, err := NewPostgresStore(pool, observer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pool, store, observer
+}
+
+func insertReleaseLostRequest(t *testing.T, ctx context.Context, pool *pgxpool.Pool, id, idempotencyKey string) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+INSERT INTO work_graph_execution_requests (
+    id, org_id, kind, scope, llm_concurrency, spend_limit_microunits,
+    correlation_id, idempotency_key, state
+) VALUES ($1,$2,'workgraph.build','{}',1,0,'release-lost-fixture',$3,'pending')`,
+		id, testOrgID, idempotencyKey,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestWorkGraphAmbiguousRecordsReleaseLostOnlyOnAnExpiredLease is the
+// CHAOS-4002 mutation-catching test: dropping the observeReleaseLost() call
+// in Ambiguous must fail this. Both directions are seeded (input symmetry): a
+// live-lease release that succeeds must NOT record anything, and an
+// expired-lease release that fails with ErrLeaseLost MUST record exactly
+// once. A second pass through the same scenario using a real
+// jobruntime.MetricsCollector (TestWorkGraphAmbiguousRecordsReleaseLostInRealPrometheusExposition,
+// below) additionally proves the PrometheusText wiring itself, which a
+// bespoke recorder like the one used here cannot: it would keep passing even
+// if writeWorkGraphLease were dropped from PrometheusText entirely.
+//
+// It also exercises the exact detail strings handler.go's two discard sites
+// pass (releaseAmbiguous on org mismatch, and on an unknown compatibility
+// outcome) as its two claims, one per site. It does not drive them through
+// the handler itself: both fire synchronously right after Claim, with no
+// time gap in which a lease genuinely expires, so the only way either one
+// meets an expired lease in production is a real concurrent reclaim racing
+// in between -- not something a mocked clock can reproduce honestly. That
+// both sites reach Ambiguous/store.ambiguous at all is already pinned,
+// unchanged by this ticket, by TestBuildRejectsTenantEnvelopeMismatchBeforeClaim
+// and TestCompatibilityFailureIsAmbiguousNotRetried in handler_test.go. What
+// this test adds is what Ambiguous itself does once reached: recording is
+// centralized in the store, not duplicated per call site, so proving it here
+// covers every caller by construction.
+func TestWorkGraphAmbiguousRecordsReleaseLostOnlyOnAnExpiredLease(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	pool, store, observer := startWorkGraphReleaseLostFixture(t, ctx)
+
+	const liveRequestID = "00000000-0000-4000-8000-000000000201"
+	const expiredRequestID = "00000000-0000-4000-8000-000000000202"
+	insertReleaseLostRequest(t, ctx, pool, liveRequestID, "workgraph:release-lost-live")
+	insertReleaseLostRequest(t, ctx, pool, expiredRequestID, "workgraph:release-lost-expired")
+
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	// Still within the lease: Ambiguous succeeds and must not record
+	// release_lost -- a claimant that still holds its lease standing its own
+	// row down deliberately is not a stall signal. Detail text matches
+	// handler.go's org-mismatch discard site.
+	liveClaim, err := store.Claim(ctx, liveRequestID, KindBuild)
+	if err != nil || liveClaim == nil {
+		t.Fatalf("live claim = %#v, %v", liveClaim, err)
+	}
+	if err := store.Ambiguous(ctx, *liveClaim, "claimed request no longer matches River envelope"); err != nil {
+		t.Fatalf("live-lease Ambiguous = %v", err)
+	}
+	if observer.releaseLost != 0 {
+		t.Fatalf("live-lease release-lost count = %d, want 0", observer.releaseLost)
+	}
+
+	// Claim a second request, then let its lease expire before attempting to
+	// release it -- the exact CHAOS-3991 shape: the claimant has outlived its
+	// own lease and can no longer stand its row down. Detail text matches
+	// handler.go's compatibility-execution-unknown discard site.
+	expiredClaim, err := store.Claim(ctx, expiredRequestID, KindBuild)
+	if err != nil || expiredClaim == nil {
+		t.Fatalf("expired-lease claim = %#v, %v", expiredClaim, err)
+	}
+	var preReleaseToken string
+	var preReleaseLeaseExpiry time.Time
+	if err := pool.QueryRow(ctx, `SELECT claim_token::text, lease_expires_at FROM work_graph_execution_requests WHERE id = $1`, expiredRequestID).Scan(&preReleaseToken, &preReleaseLeaseExpiry); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(store.lease + time.Second)
+	err = store.Ambiguous(ctx, *expiredClaim, "compatibility execution outcome is unknown")
+	if !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("expired-lease Ambiguous = %v, want ErrLeaseLost", err)
+	}
+	if observer.releaseLost != 1 {
+		t.Fatalf("expired-lease release-lost count = %d, want 1", observer.releaseLost)
+	}
+
+	// The fence itself must be unchanged by the lost release: the row stays
+	// exactly as the expired claimant left it -- state, claim_token, AND
+	// lease_expires_at -- for a live claimant to reclaim. A regression that
+	// clears the token or lease while leaving state alone would only be
+	// caught by checking all three.
+	var state, postReleaseToken string
+	var postReleaseLeaseExpiry time.Time
+	if err := pool.QueryRow(ctx, `SELECT state, claim_token::text, lease_expires_at FROM work_graph_execution_requests WHERE id = $1`, expiredRequestID).Scan(&state, &postReleaseToken, &postReleaseLeaseExpiry); err != nil {
+		t.Fatal(err)
+	}
+	if state != "running" {
+		t.Fatalf("expired-lease request state = %q, want unchanged 'running'", state)
+	}
+	if postReleaseToken != preReleaseToken {
+		t.Fatalf("expired-lease claim_token = %q, want unchanged %q", postReleaseToken, preReleaseToken)
+	}
+	if !postReleaseLeaseExpiry.Equal(preReleaseLeaseExpiry) {
+		t.Fatalf("expired-lease lease_expires_at = %v, want unchanged %v", postReleaseLeaseExpiry, preReleaseLeaseExpiry)
+	}
+}
+
+// TestWorkGraphAmbiguousRecordsReleaseLostInRealPrometheusExposition proves
+// the full production wiring end to end: a real jobruntime.MetricsCollector,
+// not a bespoke recorder, so this fails if writeWorkGraphLease is ever
+// dropped from PrometheusText -- a gap the bespoke-recorder test above
+// cannot see (adversarial codex review, CHAOS-4002).
+func TestWorkGraphAmbiguousRecordsReleaseLostInRealPrometheusExposition(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer instance.Close(context.Background())
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createExecutionTables(t, ctx, pool)
+
+	collector, err := jobruntime.NewMetricsCollector(jobruntime.MetricDimensions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(collector.PrometheusText(), "worker_workgraph_lease_release_lost_total 0\n") {
+		t.Fatal("collector did not pre-seed worker_workgraph_lease_release_lost_total at 0")
+	}
+
+	store, err := NewPostgresStore(pool, collector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	const requestID = "00000000-0000-4000-8000-000000000205"
+	insertReleaseLostRequest(t, ctx, pool, requestID, "workgraph:release-lost-prometheus")
+	claim, err := store.Claim(ctx, requestID, KindBuild)
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, %v", claim, err)
+	}
+	now = now.Add(store.lease + time.Second)
+	if err := store.Ambiguous(ctx, *claim, "compatibility execution outcome is unknown"); !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("Ambiguous = %v, want ErrLeaseLost", err)
+	}
+	if !strings.Contains(collector.PrometheusText(), "worker_workgraph_lease_release_lost_total 1\n") {
+		t.Fatalf("PrometheusText did not reflect the release-lost observation:\n%s", collector.PrometheusText())
+	}
+}

--- a/internal/jobs/workgraph/postgres.go
+++ b/internal/jobs/workgraph/postgres.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/joboutbox"
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -23,16 +24,33 @@ func validUUID(value string) bool { return uuidPattern.MatchString(value) }
 // ledger has one row per request; an expired reclaim replaces its fencing token
 // atomically rather than leaving a stale token beside a new request owner.
 type PostgresStore struct {
-	pool  *pgxpool.Pool
-	lease time.Duration
-	now   func() time.Time
+	pool          *pgxpool.Pool
+	lease         time.Duration
+	now           func() time.Time
+	leaseObserver jobruntime.WorkGraphLeaseObserver
 }
 
-func NewPostgresStore(pool *pgxpool.Pool) (*PostgresStore, error) {
+func NewPostgresStore(
+	pool *pgxpool.Pool,
+	observers ...jobruntime.WorkGraphLeaseObserver,
+) (*PostgresStore, error) {
 	if pool == nil {
 		return nil, ErrUnavailable
 	}
-	return &PostgresStore{pool: pool, lease: defaultLease, now: time.Now}, nil
+	var observer jobruntime.WorkGraphLeaseObserver
+	if len(observers) > 0 {
+		observer = observers[0]
+	}
+	return &PostgresStore{pool: pool, lease: defaultLease, now: time.Now, leaseObserver: observer}, nil
+}
+
+// observeReleaseLost records a durably resolved release-lost outcome. Metric
+// failures are dropped: telemetry must never decide whether a run can make
+// progress.
+func (store *PostgresStore) observeReleaseLost() {
+	if store.leaseObserver != nil {
+		_ = store.leaseObserver.ObserveWorkGraphLeaseReleaseLost()
+	}
 }
 
 func (store *PostgresStore) Claim(ctx context.Context, requestID string, kind Kind) (*Claim, error) {
@@ -139,8 +157,16 @@ func (store *PostgresStore) Fail(ctx context.Context, claim Claim, detail string
 	return store.transition(ctx, claim, "failed", nil, detail)
 }
 
+// Ambiguous stands a claimed request back down when its outcome could not be
+// determined. Release is fenced on a live lease, so a claimant that has
+// already outlived its lease cannot release it; that outcome is recorded
+// rather than left for the caller to discard (CHAOS-4002).
 func (store *PostgresStore) Ambiguous(ctx context.Context, claim Claim, detail string) error {
-	return store.transition(ctx, claim, "ambiguous", nil, detail)
+	err := store.transition(ctx, claim, "ambiguous", nil, detail)
+	if errors.Is(err, ErrLeaseLost) {
+		store.observeReleaseLost()
+	}
+	return err
 }
 
 func (store *PostgresStore) transition(ctx context.Context, claim Claim, state string, evidence []byte, detail string) error {


### PR DESCRIPTION
## Summary

CHAOS-3991 closed this for the daily-metrics domain only: `ReleasePartition`/`ReleaseFinalize` now record `worker_daily_metrics_lease_total{stage, result="release_lost"}` when a claimant that has already outlived its own lease cannot stand its row down. Workgraph (`Ambiguous`) and remaining (`ReleasePartition`) carry the exact same fenced-release shape (`... AND lease_expires_at > now`) and the exact same silent-discard defect — the caller's own `handler.go` discards the error at every failure exit — and both were left uninstrumented. This is the leading indicator of the CHAOS-3991 class of stall: a rising `release_lost` count means claimants are outliving their leases, the precondition for orphaned leases that stranded production fanout for fourteen hours.

## What changed

- `internal/jobruntime/observer.go`: `WorkGraphLeaseObserver` and `RemainingMetricsLeaseObserver`, mirroring `DailyMetricsLeaseObserver`'s shape (a narrow capability the store depends on directly — generic runtime middleware can't infer this from a job retry).
- `internal/jobruntime/telemetry.go`: two new pre-seeded counters, `worker_workgraph_lease_release_lost_total` and `worker_remaining_metrics_lease_release_lost_total`. Unlike daily (two distinct lease mechanisms: partition + finalize), workgraph and remaining each have exactly **one** lease-fenced release path, so there's no stage/result dimension — deliberately, to stay minimal per the ticket's "record only a durable fact" scope. Both are pre-seeded for free: plain `uint64` fields, always written by `PrometheusText`, no map to seed.
- `internal/jobs/workgraph/postgres.go` / `internal/jobs/metrics/remaining/postgres.go`: `NewPostgresStore` takes a variadic observer param, matching daily's exact existing signature. `Ambiguous`/`ReleasePartition` record `release_lost` only on their `ErrLeaseLost` branch — never on success, never on `ErrUnavailable`/`ErrInvalidState`. **The fenced `UPDATE` predicate itself is unchanged in both stores** — this is purely about recording the outcome, never widening release authority.
- `cmd/dev-health-worker/{workgraph,daily}.go`: wired via the same type-assertion idiom daily's own observer already uses (`daily.go` also constructs the `remaining` store).

## Testing

Mutation-checked integration tests (real Postgres testcontainers) in both packages, each seeding **both directions** (input symmetry): a live-lease release that succeeds must not record anything; an expired-lease release that fails with `ErrLeaseLost` must record exactly once — plus a full fence-unchanged assertion (`status`/`state`, `claim_token`, `lease_expires_at`, not just status).

Adversarial codex review (xhigh) caught two real gaps before this reached a PR, both fixed:
1. My first-draft "two release sites" claim for `remaining` was wrong — `handler.go` has **three** (`LoadRun` failure, validation mismatch, lease-loss-during-work), and the `LoadRun`-failure site had **zero** existing coverage. Added `TestPartitionHandlerReleasesClaimOnLoadRunFailure` (pure unit test, no Docker) to close the actual gap.
2. Both integration tests used a bespoke recorder observer, so they'd stay green even if the `PrometheusText` wiring were deleted entirely. Added a second test per package (`Test*RecordsReleaseLostInRealPrometheusExposition`) using a real `jobruntime.MetricsCollector`, asserting the actual exposition text before and after.

All four integration tests run against real Postgres, rc=0. Negative-controlled the core recording behavior by temporarily deleting the `observeReleaseLost()` calls and confirming both original tests fail, then restored.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test -count=3 -race` clean on `internal/jobruntime`, `internal/jobs/workgraph`, `internal/jobs/metrics/remaining`, `cmd/dev-health-worker`
- [x] `go vet -tags=integration` clean
- [x] 4 integration tests pass against real Postgres testcontainers (2 mutation-catching, 2 real-Prometheus-exposition)
- [x] Negative-controlled: deleted `observeReleaseLost()` calls, confirmed both catch it, restored
- [x] `telemetry_test.go`'s deterministic-exposition-order test extended and negative-controlled the same way
- [x] Codex adversarial review (xhigh) — two findings, both fixed; verified constructor call-site compatibility across the whole repo (scheduler/`fixed.go`, `sync_dispatch.go` correctly omit observers — producer-only paths that never call the release methods)

No self-merge; awaiting review.