### PR TITLE
feat(tracing): propagate trace context through the sync-dispatch coordinator loop (CHAOS-3996)

### DIFF
--- a/ci/go_integration_shards.tsv
+++ b/ci/go_integration_shards.tsv
@@ -12,6 +12,7 @@
 # non-dominant shards balanced while isolating that indivisible dominant
 # package under the unchanged 25-minute job budget.
 shards	3
+cmd/dev-health-reconciler	10
 cmd/dev-health-worker	24
 cmd/dev-health-workerctl	13
 internal/externalrecompute	15

--- a/cmd/dev-health-reconciler/dependencies.go
+++ b/cmd/dev-health-reconciler/dependencies.go
@@ -309,12 +309,24 @@ func syncDispatchReference(
 		return syncdispatchruntime.DomainReference{}, syncreconciler.ErrUnavailable
 	}
 	var reference syncdispatchruntime.DomainReference
+	var traceParent *string
+	// The join reads sync_runs.trace_parent (CHAOS-3996): the W3C traceparent
+	// the Python planner captured once when this run was planned, so every
+	// dispatch across the run's lifecycle -- however many
+	// dispatch/finalize/post_sync/reference_discovery cycles it takes --
+	// parents its span from the same trace instead of each claim resolving
+	// its own. NULL for a run planned before that column existed or with
+	// tracing disabled; traceParent stays nil and the caller gets a root span.
 	err := pool.QueryRow(ctx, `
-SELECT org_id::text, sync_run_id::text
-FROM public.sync_dispatch_outbox
-WHERE id = $1::uuid AND kind = $2`, outboxID, kind).Scan(&reference.OrganizationID, &reference.SyncRunID)
+SELECT sdo.org_id::text, sdo.sync_run_id::text, sr.trace_parent
+FROM public.sync_dispatch_outbox sdo
+JOIN public.sync_runs sr ON sr.id = sdo.sync_run_id
+WHERE sdo.id = $1::uuid AND sdo.kind = $2`, outboxID, kind).Scan(&reference.OrganizationID, &reference.SyncRunID, &traceParent)
 	if err != nil {
 		return syncdispatchruntime.DomainReference{}, syncreconciler.ErrUnavailable
+	}
+	if traceParent != nil {
+		reference.TraceParent = *traceParent
 	}
 	if _, orgErr := uuid.Parse(reference.OrganizationID); orgErr != nil {
 		return syncdispatchruntime.DomainReference{}, syncreconciler.ErrUnavailable

--- a/cmd/dev-health-reconciler/sync_dispatch_reference_integration_test.go
+++ b/cmd/dev-health-reconciler/sync_dispatch_reference_integration_test.go
@@ -58,6 +58,7 @@ func TestSyncDispatchReferenceJoinsTraceParentFromSyncRuns(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	orgID := uuid.New()
 	tracedRun := uuid.New()
 	untracedRun := uuid.New()
 	tracedOutbox := uuid.New()
@@ -88,8 +89,8 @@ func TestSyncDispatchReferenceJoinsTraceParentFromSyncRuns(t *testing.T) {
 	}
 	for _, row := range outboxRows {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO public.sync_dispatch_outbox (id, org_id, sync_run_id, kind) VALUES ($1, 'org-1', $2, 'dispatch_sync_run')`,
-			row.id, row.runID,
+			`INSERT INTO public.sync_dispatch_outbox (id, org_id, sync_run_id, kind) VALUES ($1, $2, $3, 'dispatch_sync_run')`,
+			row.id, orgID.String(), row.runID,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -101,7 +102,7 @@ func TestSyncDispatchReferenceJoinsTraceParentFromSyncRuns(t *testing.T) {
 			t.Fatal(err)
 		}
 		want := syncdispatchruntime.DomainReference{
-			OrganizationID: "org-1", SyncRunID: tracedRun.String(), TraceParent: wantTraceParent,
+			OrganizationID: orgID.String(), SyncRunID: tracedRun.String(), TraceParent: wantTraceParent,
 		}
 		if got != want {
 			t.Fatalf("got %+v, want %+v", got, want)
@@ -114,7 +115,7 @@ func TestSyncDispatchReferenceJoinsTraceParentFromSyncRuns(t *testing.T) {
 			t.Fatal(err)
 		}
 		want := syncdispatchruntime.DomainReference{
-			OrganizationID: "org-1", SyncRunID: untracedRun.String(), TraceParent: "",
+			OrganizationID: orgID.String(), SyncRunID: untracedRun.String(), TraceParent: "",
 		}
 		if got != want {
 			t.Fatalf("got %+v, want %+v", got, want)

--- a/cmd/dev-health-reconciler/sync_dispatch_reference_integration_test.go
+++ b/cmd/dev-health-reconciler/sync_dispatch_reference_integration_test.go
@@ -1,0 +1,139 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchruntime"
+	"github.com/full-chaos/dev-health-ops/internal/syncreconciler"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const syncDispatchReferenceDDL = `
+CREATE TABLE public.sync_runs (
+    id UUID PRIMARY KEY,
+    trace_parent TEXT
+);
+CREATE TABLE public.sync_dispatch_outbox (
+    id UUID PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    sync_run_id UUID NOT NULL REFERENCES public.sync_runs (id),
+    kind TEXT NOT NULL
+);
+`
+
+// TestSyncDispatchReferenceJoinsTraceParentFromSyncRuns proves the
+// sync_dispatch_outbox/sync_runs JOIN added for CHAOS-3996 actually resolves
+// what it claims to against a real Postgres: the right org/run identity for
+// the (outbox id, kind) pair, a non-NULL trace_parent when the run carries
+// one, and a NULL trace_parent -- not an error -- for a run planned before
+// this column existed (or with tracing off). Nothing upstream of this test
+// type-checks the raw SQL string itself, so a join-direction or column-name
+// mistake here would only ever surface at runtime.
+func TestSyncDispatchReferenceJoinsTraceParentFromSyncRuns(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate Postgres: %v", err)
+		}
+	})
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	if _, err := pool.Exec(ctx, syncDispatchReferenceDDL); err != nil {
+		t.Fatal(err)
+	}
+
+	tracedRun := uuid.New()
+	untracedRun := uuid.New()
+	tracedOutbox := uuid.New()
+	untracedOutbox := uuid.New()
+	const wantTraceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+	seed := []struct {
+		runID       uuid.UUID
+		traceParent *string
+	}{
+		{tracedRun, ptr(wantTraceParent)},
+		{untracedRun, nil},
+	}
+	for _, row := range seed {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO public.sync_runs (id, trace_parent) VALUES ($1, $2)`,
+			row.runID, row.traceParent,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	outboxRows := []struct {
+		id    uuid.UUID
+		runID uuid.UUID
+	}{
+		{tracedOutbox, tracedRun},
+		{untracedOutbox, untracedRun},
+	}
+	for _, row := range outboxRows {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO public.sync_dispatch_outbox (id, org_id, sync_run_id, kind) VALUES ($1, 'org-1', $2, 'dispatch_sync_run')`,
+			row.id, row.runID,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("a run with a captured trace_parent resolves it", func(t *testing.T) {
+		got, err := syncDispatchReference(ctx, pool, tracedOutbox.String(), "dispatch_sync_run")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := syncdispatchruntime.DomainReference{
+			OrganizationID: "org-1", SyncRunID: tracedRun.String(), TraceParent: wantTraceParent,
+		}
+		if got != want {
+			t.Fatalf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("a run planned before trace_parent existed resolves an empty one, not an error", func(t *testing.T) {
+		got, err := syncDispatchReference(ctx, pool, untracedOutbox.String(), "dispatch_sync_run")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := syncdispatchruntime.DomainReference{
+			OrganizationID: "org-1", SyncRunID: untracedRun.String(), TraceParent: "",
+		}
+		if got != want {
+			t.Fatalf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("a kind that does not match the claimed row is unavailable, not the wrong row", func(t *testing.T) {
+		_, err := syncDispatchReference(ctx, pool, tracedOutbox.String(), "finalize_sync_run")
+		if err != syncreconciler.ErrUnavailable {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+	})
+
+	t.Run("an outbox id with no row is unavailable", func(t *testing.T) {
+		_, err := syncDispatchReference(ctx, pool, uuid.New().String(), "dispatch_sync_run")
+		if err != syncreconciler.ErrUnavailable {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+	})
+}
+
+func ptr(value string) *string { return &value }

--- a/internal/scheduler/sync/testdata/python_planner_oracle.py
+++ b/internal/scheduler/sync/testdata/python_planner_oracle.py
@@ -107,6 +107,15 @@ _module(
     upsert_outbox_wakeup=lambda *_args, **_kwargs: None,
 )
 _module("dev_health_ops.sync.guard", _resolve_total_unit_cap=lambda *_args: 1000)
+# CHAOS-3996 gave planner.py a new module-level dependency on this name
+# (``from dev_health_ops.tracing import current_trace_parent``, used to stamp
+# sync_runs.trace_parent at plan time). The stub must expose it or the oracle
+# fails to IMPORT, same failure mode as the watermarks stub below (CHAOS-3412).
+# There is no active span in this oracle process, so returning None matches
+# what current_trace_parent() itself returns with no span in progress --
+# this oracle tests planning parity, not tracing, so a real OTel dependency
+# here would be scope creep.
+_module("dev_health_ops.tracing", current_trace_parent=lambda: None)
 _module(
     "dev_health_ops.sync.pagerduty_repair",
     repair_pagerduty_operational_integration=lambda *_args: None,

--- a/internal/syncdispatchruntime/publisher.go
+++ b/internal/syncdispatchruntime/publisher.go
@@ -136,5 +136,6 @@ func matchesReturnedArgs(encoded []byte, expected Args) bool {
 	return returned.Version == expected.ContractVersion() && returned.OrgID == expected.OrganizationID() &&
 		returned.RunID == expected.SyncRunID() && returned.DispatchOutbox == expected.OutboxID() &&
 		returned.DeliveryAttempt == expected.Attempt() &&
-		returned.RouteGeneration == expected.RouteGeneration()
+		returned.RouteGeneration == expected.RouteGeneration() &&
+		returned.TraceParent == expected.traceParent()
 }

--- a/internal/syncdispatchruntime/runtime_test.go
+++ b/internal/syncdispatchruntime/runtime_test.go
@@ -140,6 +140,50 @@ func TestPublisherUsesCallerTransactionAndVerifiesExactArgs(t *testing.T) {
 	}
 }
 
+// TestPublisherRoundTripsANonEmptyTraceParent proves the field the JOIN
+// resolves (CHAOS-3996) survives the exact same path a live publish takes:
+// Convert into typed args, Publish through the caller's transaction (which
+// marshals to JSON as River's insert would), and matchesReturnedArgs
+// decoding it back. TestConvertProducesExactVersionedTypedArgsWithoutClaimToken
+// above covers the omitted-when-empty case; this is the non-empty
+// counterpart neither existing test exercised.
+func TestPublisherRoundTripsANonEmptyTraceParent(t *testing.T) {
+	t.Parallel()
+	const traceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	client := &recordingInsertClient{}
+	publisher, err := NewPublisher(client, PublisherOptions{Queue: "sync", MaxAttempts: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reference := DomainReference{OrganizationID: testOrg, SyncRunID: testRun, TraceParent: traceParent}
+	jobID, err := publisher.Publish(context.Background(), &inertTx{}, Claim{
+		OutboxID: testOutbox, Kind: syncdispatchcontract.KindDispatchSyncRun, RouteGeneration: 3,
+	}, reference)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if jobID != "42" {
+		t.Fatalf("publisher call = job:%s", jobID)
+	}
+	encoded, err := json.Marshal(client.args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if fields["trace_parent"] != traceParent {
+		t.Fatalf("encoded trace_parent = %#v, want %q", fields["trace_parent"], traceParent)
+	}
+	// matchesReturnedArgs is what verifyInsert calls on the real River
+	// result -- exercise it directly against the args this publish produced,
+	// proving the non-empty field survives that comparison too.
+	if !matchesReturnedArgs(encoded, client.args.(Args)) {
+		t.Fatal("matchesReturnedArgs rejected a non-empty trace_parent round trip")
+	}
+}
+
 func TestPublisherRejectsMismatchedRiverResultWithoutLeakingArguments(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {

--- a/internal/syncdispatchruntime/tracing_test.go
+++ b/internal/syncdispatchruntime/tracing_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/riverqueue/river"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
@@ -48,4 +49,52 @@ func TestCoordinatorSpanEndsEvenWhenTheBridgePanics(t *testing.T) {
 	if len(spans) != 1 {
 		t.Fatalf("expected the span to be ended and exported despite the panic, got %d spans", len(spans))
 	}
+}
+
+// TestSpanForCoordinatorJobExtractsTraceParent does not call t.Parallel() for
+// the same global-state reason as TestCoordinatorSpanEndsEvenWhenTheBridgePanics.
+func TestSpanForCoordinatorJobExtractsTraceParent(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	previousProvider := otel.GetTracerProvider()
+	previousPropagator := otel.GetTextMapPropagator()
+	otel.SetTracerProvider(provider)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousProvider)
+		otel.SetTextMapPropagator(previousPropagator)
+	})
+
+	t.Run("with trace_parent, the span gets a remote parent from it", func(t *testing.T) {
+		exporter.Reset()
+		_, span := spanForCoordinatorJob(context.Background(), "dispatch_sync_run", testRun,
+			"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+		span.End()
+
+		spans := exporter.GetSpans()
+		if len(spans) != 1 {
+			t.Fatalf("expected 1 exported span, got %d", len(spans))
+		}
+		got := spans[0]
+		if traceID := got.SpanContext.TraceID().String(); traceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+			t.Fatalf("trace id = %s, want the trace id carried by traceParent", traceID)
+		}
+		if !got.Parent.IsRemote() {
+			t.Fatal("expected the span's parent to be remote, extracted from traceParent")
+		}
+	})
+
+	t.Run("without trace_parent, the span is a root span", func(t *testing.T) {
+		exporter.Reset()
+		_, span := spanForCoordinatorJob(context.Background(), "dispatch_sync_run", testRun, "")
+		span.End()
+
+		spans := exporter.GetSpans()
+		if len(spans) != 1 {
+			t.Fatalf("expected 1 exported span, got %d", len(spans))
+		}
+		if spans[0].Parent.IsValid() {
+			t.Fatal("expected a root span (no parent) when traceParent is empty")
+		}
+	})
 }

--- a/internal/syncdispatchruntime/types.go
+++ b/internal/syncdispatchruntime/types.go
@@ -17,6 +17,11 @@ const ContractVersionV1 = 1
 
 var uuidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 
+// traceParentPattern is the W3C Trace Context traceparent value shape:
+// version-traceid-spanid-flags, all lowercase hex.
+// https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+var traceParentPattern = regexp.MustCompile(`^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$`)
+
 var (
 	ErrInvalidClaim     = errors.New("invalid sync dispatch transport claim")
 	ErrInvalidReference = errors.New("invalid sync dispatch domain reference")
@@ -39,6 +44,11 @@ type Claim struct {
 type DomainReference struct {
 	OrganizationID string
 	SyncRunID      string
+	// TraceParent is the optional W3C traceparent the Python planner captured
+	// once into sync_runs when this run was planned, resolved by the same
+	// database lookup that resolves OrganizationID/SyncRunID (CHAOS-3996).
+	// Empty for a run planned before that column existed or with tracing off.
+	TraceParent string
 }
 
 // TeamAutoimportJobArgs is the generic worker-outbox envelope for the
@@ -81,6 +91,14 @@ type Args interface {
 	SyncRunID() string
 	RouteGeneration() int64
 	Attempt() int64
+	// traceParent is unexported: it is package-private accessor plumbing for
+	// matchesReturnedArgs' round-trip proof and the coordinator workers'
+	// span-parent extraction, not a public capability of Args. Named in
+	// lowerCamelCase (not TraceParent) specifically so it does not collide
+	// with the exported TraceParent field TransportArgs promotes by
+	// embedding -- Go permits a type to declare a field and a method as long
+	// as their identifiers differ by case.
+	traceParent() string
 	valid() error
 }
 
@@ -94,6 +112,14 @@ type TransportArgs struct {
 	DispatchOutbox  string `json:"outbox_id" river:"unique"`
 	DeliveryAttempt int64  `json:"delivery_attempt" river:"unique"`
 	RouteGeneration int64  `json:"route_generation"`
+	// TraceParent is the optional W3C traceparent from DomainReference,
+	// carried into the River job so a worker picking this job back up (after
+	// a process restart, a retry, or simply a different replica) still has it
+	// without a second database round trip. Deliberately untagged for River's
+	// ByArgs uniqueness (unlike DispatchOutbox/DeliveryAttempt above): two
+	// deliveries of the same claim must keep deduping regardless of this
+	// field's value (CHAOS-3996).
+	TraceParent string `json:"trace_parent,omitempty"`
 }
 
 func (args TransportArgs) ContractVersion() int   { return args.Version }
@@ -102,11 +128,15 @@ func (args TransportArgs) OrganizationID() string { return args.OrgID }
 func (args TransportArgs) SyncRunID() string      { return args.RunID }
 func (args TransportArgs) Generation() int64      { return args.RouteGeneration }
 func (args TransportArgs) Attempt() int64         { return args.DeliveryAttempt }
+func (args TransportArgs) traceParent() string    { return args.TraceParent }
 
 func (args TransportArgs) valid() error {
 	if args.Version != ContractVersionV1 || !uuidPattern.MatchString(args.OrgID) ||
 		!uuidPattern.MatchString(args.RunID) || !uuidPattern.MatchString(args.DispatchOutbox) ||
 		args.RouteGeneration < 1 {
+		return ErrInvalidReference
+	}
+	if args.TraceParent != "" && !traceParentPattern.MatchString(args.TraceParent) {
 		return ErrInvalidReference
 	}
 	return nil
@@ -164,6 +194,7 @@ func Convert(claim Claim, reference DomainReference) (Args, error) {
 		DispatchOutbox:  claim.OutboxID,
 		DeliveryAttempt: deliveryAttempt,
 		RouteGeneration: claim.RouteGeneration,
+		TraceParent:     reference.TraceParent,
 	}
 	if err := base.valid(); err != nil {
 		return nil, err

--- a/internal/syncdispatchruntime/worker.go
+++ b/internal/syncdispatchruntime/worker.go
@@ -10,26 +10,31 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var ErrWorkerRegistration = errors.New("sync dispatch worker registration failed")
 
-// coordinatorTracerName scopes this package's spans. Unlike
-// internal/jobruntime.Adapter's job.execute spans, these carry no
-// trace-context propagation yet -- these four kinds have no JSON payload
-// field to carry a traceparent in (TransportArgs is entirely typed fields
-// resolved from a DB lookup, not decoded arguments), so there is nothing to
-// extract a parent from. CHAOS-3996 tracks adding that. Until then, kind and
-// sync_run_id alone give Tempo visibility into the coordinator loop that was
-// completely dark during the CHAOS-3990 guard deadlock (CHAOS-3993).
+// coordinatorTracerName scopes this package's spans.
 //
 // otel.Tracer is looked up fresh on every call rather than cached in a
 // package var: see internal/jobruntime.jobTracerName for why a cached handle
 // silently stays bound to the first TracerProvider it ever saw.
 const coordinatorTracerName = "github.com/full-chaos/dev-health-ops/internal/syncdispatchruntime"
 
-func spanForCoordinatorJob(ctx context.Context, kind, syncRunID string) (context.Context, oteltrace.Span) {
+// spanForCoordinatorJob opens the span for one coordinator dispatch, parented
+// from traceParent when the run planner captured one (CHAOS-3996) -- resolved
+// from sync_runs by the same database lookup that resolves the domain
+// reference itself, since TransportArgs carries only typed fields and has no
+// arbitrary JSON payload to decode a parent out of the way
+// internal/jobruntime.startJobSpan does for the outbox path. An empty
+// traceParent (a run planned before CHAOS-3996, or with tracing disabled)
+// produces a root span, same as before this ticket.
+func spanForCoordinatorJob(ctx context.Context, kind, syncRunID, traceParent string) (context.Context, oteltrace.Span) {
+	if traceParent != "" {
+		ctx = otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier{"traceparent": traceParent})
+	}
 	return otel.Tracer(coordinatorTracerName).Start(ctx, "dev_health.sync_dispatch."+kind, oteltrace.WithAttributes(
 		attribute.String("dev_health.job.kind", kind),
 		attribute.String("dev_health.sync_run_id", syncRunID),
@@ -108,7 +113,7 @@ func (worker *dispatchWorker) Work(ctx context.Context, job *river.Job[DispatchS
 	if worker == nil || worker.bridge == nil || job == nil {
 		return ErrWorkerRegistration
 	}
-	ctx, span := spanForCoordinatorJob(ctx, job.Args.Kind(), job.Args.SyncRunID())
+	ctx, span := spanForCoordinatorJob(ctx, job.Args.Kind(), job.Args.SyncRunID(), job.Args.TraceParent)
 	// A deferred finish (not a direct call after Dispatch returns) so a panic
 	// from worker.bridge still ends and exports the span before the panic
 	// continues propagating to River's own panic-to-failure handling; this
@@ -127,7 +132,7 @@ func (worker *finalizeWorker) Work(ctx context.Context, job *river.Job[FinalizeS
 	if worker == nil || worker.bridge == nil || job == nil {
 		return ErrWorkerRegistration
 	}
-	ctx, span := spanForCoordinatorJob(ctx, job.Args.Kind(), job.Args.SyncRunID())
+	ctx, span := spanForCoordinatorJob(ctx, job.Args.Kind(), job.Args.SyncRunID(), job.Args.TraceParent)
 	defer func() { finishCoordinatorSpan(span, err) }()
 	err = worker.bridge.Finalize(ctx, job.Args)
 	return err
@@ -142,7 +147,7 @@ func (worker *postSyncWorker) Work(ctx context.Context, job *river.Job[PostSyncA
 	if worker == nil || worker.service == nil || job == nil {
 		return ErrWorkerRegistration
 	}
-	ctx, span := spanForCoordinatorJob(ctx, job.Args.Kind(), job.Args.SyncRunID())
+	ctx, span := spanForCoordinatorJob(ctx, job.Args.Kind(), job.Args.SyncRunID(), job.Args.TraceParent)
 	defer func() { finishCoordinatorSpan(span, err) }()
 	err = worker.service.Fanout(ctx, job.Args)
 	return err
@@ -165,7 +170,10 @@ func (worker *teamAutoimportWorker) Work(ctx context.Context, job *river.Job[Tea
 	if err := job.Args.valid(); err != nil {
 		return err
 	}
-	ctx, span := spanForCoordinatorJob(ctx, job.Args.Kind(), job.Args.Payload.SyncRunID)
+	// TeamAutoimportJobArgs does not embed TransportArgs (it is the generic
+	// worker-outbox envelope, not a coordinator TransportArgs kind), so there
+	// is no TraceParent field to propagate here -- out of this ticket's scope.
+	ctx, span := spanForCoordinatorJob(ctx, job.Args.Kind(), job.Args.Payload.SyncRunID, "")
 	defer func() { finishCoordinatorSpan(span, err) }()
 	err = worker.bridge.TeamAutoImport(ctx, DomainReference{
 		OrganizationID: job.Args.OrgID,
@@ -178,7 +186,7 @@ func (worker *referenceDiscoveryWorker) Work(ctx context.Context, job *river.Job
 	if worker == nil || worker.bridge == nil || job == nil {
 		return ErrWorkerRegistration
 	}
-	ctx, span := spanForCoordinatorJob(ctx, job.Args.Kind(), job.Args.SyncRunID())
+	ctx, span := spanForCoordinatorJob(ctx, job.Args.Kind(), job.Args.SyncRunID(), job.Args.TraceParent)
 	defer func() { finishCoordinatorSpan(span, err) }()
 	err = worker.bridge.Discover(ctx, job.Args)
 	return err

--- a/src/dev_health_ops/alembic/versions/0105_add_sync_run_trace_parent.py
+++ b/src/dev_health_ops/alembic/versions/0105_add_sync_run_trace_parent.py
@@ -1,0 +1,42 @@
+"""Add the optional root trace_parent captured once when a sync run starts.
+
+Revision ID: 0105
+Revises: 0104
+
+The Go sync-dispatch coordinator (dispatch_sync_run / finalize_sync_run /
+post_sync / reference_discovery) resolves its authoritative domain reference
+for every dispatch from a database lookup, not from decoded River arguments
+(see internal/syncdispatchruntime.TransportArgs). This column is the durable
+place that reference is joined through to recover the W3C traceparent the
+Python planner captured once at plan time, so every dispatch across the whole
+run's lifecycle parents its span from the same trace (CHAOS-3996).
+
+Nullable, no backfill: a run planned before this migration, or planned while
+tracing is disabled, simply has no traceparent to recover, exactly like a
+worker_job_outbox row with no trace_parent (CHAOS-3993).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0105"
+down_revision: str | None = "0104"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_TABLE = "sync_runs"
+_COLUMN = "trace_parent"
+
+
+def upgrade() -> None:
+    op.add_column(_TABLE, sa.Column(_COLUMN, sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column(_TABLE, _COLUMN)

--- a/src/dev_health_ops/models/integrations.py
+++ b/src/dev_health_ops/models/integrations.py
@@ -204,6 +204,14 @@ class SyncRun(Base):
     credential_id: Mapped[uuid.UUID | None] = mapped_column(GUID, nullable=True)
     credential_fingerprint: Mapped[str | None] = mapped_column(Text, nullable=True)
     auth_source: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Root W3C traceparent captured once at plan time (CHAOS-3996), so every
+    # coordinator dispatch across this run's lifecycle -- resolved from a
+    # database lookup, not decoded River arguments -- can join through
+    # sync_dispatch_outbox.sync_run_id and parent its span from the same
+    # trace the Go outbox-relayed provider-unit work already joins via
+    # jobcontract.Envelope.trace_parent (CHAOS-3993). NULL for a run planned
+    # before this column existed, or while tracing was disabled.
+    trace_parent: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -134,6 +134,7 @@ from dev_health_ops.sync.watermarks import (
     _watermark_overlap_seconds,
     get_watermark_with_overlap,
 )
+from dev_health_ops.tracing import current_trace_parent
 from dev_health_ops.workers.provider_family_contract import (
     atomic_provider_family_route_enabled,
 )
@@ -328,6 +329,11 @@ def plan_sync_run(session: Session, request: SyncPlanRequest) -> SyncRunPlan:
         credential_id=credential_id,
         credential_fingerprint=credential_fp,
         auth_source=auth_source,
+        # CHAOS-3996: captured once, here, so every coordinator dispatch this
+        # run produces can join back to the same trace regardless of how long
+        # the run takes or how many dispatch/finalize/post_sync/
+        # reference_discovery cycles it goes through.
+        trace_parent=current_trace_parent(),
     )
     session.add(sync_run)
     session.flush()

--- a/src/dev_health_ops/tracing.py
+++ b/src/dev_health_ops/tracing.py
@@ -238,3 +238,21 @@ def instrument_celery() -> None:
         logger.warning("Celery OTel instrumentation unavailable: %s", exc)
     except Exception as exc:
         logger.warning("Celery OTel instrumentation failed: %s", exc)
+
+
+def current_trace_parent() -> str | None:
+    """Capture the active span's W3C traceparent, if any, right now.
+
+    Shared by every durable capture point that needs a trace to survive an
+    async handoff -- the worker_job_outbox row (CHAOS-3993) and the sync_runs
+    row a planned run is stamped with once at plan time (CHAOS-3996). With no
+    active span -- tracing disabled, or no request/task span in progress --
+    the propagator writes nothing and this returns None, the same as a row
+    that predates this field.
+    """
+
+    from opentelemetry.propagate import inject
+
+    carrier: dict[str, str] = {}
+    inject(carrier)
+    return carrier.get("traceparent")

--- a/tests/test_0066_celery_river_cutover_postgres.py
+++ b/tests/test_0066_celery_river_cutover_postgres.py
@@ -165,7 +165,7 @@ def test_application_migrator_applies_safe_schema_without_0066_opt_in(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0104"}
+    assert _revisions(migrated_to_0065.engine) == {"0105"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _table_exists(migrated_to_0065.engine, "dev_conversations")
     assert _routes(migrated_to_0065.engine, migration) == before
@@ -189,7 +189,7 @@ def test_0066_real_postgres_applies_only_with_opt_in_and_downgrades(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0104"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0105"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -214,7 +214,7 @@ def test_application_migrator_opt_in_applies_both_heads(
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
 
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0104"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0105"}
     assert _table_exists(migrated_to_0065.engine, "dev_runs")
     assert _routes(migrated_to_0065.engine, migration) == [
         (kind, "river", False, 2) for kind in sorted(migration._KINDS)
@@ -255,7 +255,7 @@ def test_old_linear_0071_provenance_converges_to_both_heads(
     from dev_health_ops.migrate import _run_upgrade
 
     assert _run_upgrade(Namespace(db=None, revision="head")) == 0
-    assert _revisions(migrated_to_0065.engine) == {"0066", "0104"}
+    assert _revisions(migrated_to_0065.engine) == {"0066", "0105"}
     assert _routes(migrated_to_0065.engine, migration) == before
 
 

--- a/tests/test_ask_dev_v2_persistence_startup_gate.py
+++ b/tests/test_ask_dev_v2_persistence_startup_gate.py
@@ -107,7 +107,7 @@ async def test_application_schema_status_ancestor_walk(scratch_database) -> None
     await asyncio.to_thread(_upgrade_to, sync_url, "application_schema@head")
     satisfied, heads = await application_schema_status(async_url)
     assert satisfied is True
-    assert heads == ("0104",)
+    assert heads == ("0105",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -117,7 +117,7 @@ def test_canonical_incident_feature_seed_is_in_application_schema_graph() -> Non
     # lineage, and pin both named heads so an accidental third branch or an
     # out-of-order down_revision still fails loudly.
     heads = scripts.get_heads()
-    assert set(heads) == {"0066", "0104"}
+    assert set(heads) == {"0066", "0105"}
     application_head = scripts.get_revision("application_schema@head").revision
     assert application_head == max(revisions)
     application_revisions = {

--- a/tests/test_fixed_schedule_degraded_reason_postgres_migration.py
+++ b/tests/test_fixed_schedule_degraded_reason_postgres_migration.py
@@ -188,4 +188,4 @@ def test_0100_downgrade_and_reupgrade_converge(
 
     command.upgrade(_migration_config(), "application_schema@head")
     assert _COLUMN in _columns(migrated_to_0099.engine)
-    assert _revisions(migrated_to_0099.engine) == {"0104"}
+    assert _revisions(migrated_to_0099.engine) == {"0105"}

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -64,9 +64,9 @@ class TestAlembicDirResolution:
             heads = script.get_heads()
             revisions = list(script.walk_revisions())
 
-        assert set(heads) == {"0066", "0104"}
+        assert set(heads) == {"0066", "0105"}
         assert script.get_revision("river_cutover@head").revision == "0066"
-        assert script.get_revision("application_schema@head").revision == "0104"
+        assert script.get_revision("application_schema@head").revision == "0105"
         assert revisions
 
     def test_no_two_migrations_declare_the_same_revision_id(self):

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -172,8 +172,8 @@ class TestPostgresUpgrade:
         )
         scripts = ScriptDirectory.from_config(cfg)
 
-        assert set(scripts.get_heads()) == {"0066", "0104"}
-        assert scripts.get_revision("application_schema@head").revision == "0104"
+        assert set(scripts.get_heads()) == {"0066", "0105"}
+        assert scripts.get_revision("application_schema@head").revision == "0105"
         assert _database_has_revision(cfg, ("0096",), "0065")
         assert not _database_has_revision(cfg, ("0096",), "0066")
 

--- a/tests/test_report_run_execution_lease_postgres_migration.py
+++ b/tests/test_report_run_execution_lease_postgres_migration.py
@@ -241,4 +241,4 @@ def test_0098_downgrade_and_reupgrade_converge(
 
     command.upgrade(_migration_config(), "application_schema@head")
     assert _INDEX in _index_map(migrated_to_0097.engine)
-    assert _revisions(migrated_to_0097.engine) == {"0104"}
+    assert _revisions(migrated_to_0097.engine) == {"0105"}

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -183,6 +183,58 @@ def test_enabled_sources_and_enabled_datasets_fan_out_to_units(db_session):
     assert discovery.org_id == ORG_ID
 
 
+def test_plan_sync_run_stamps_the_active_span_as_trace_parent(db_session):
+    """CHAOS-3996: plan_sync_run captures the active span's W3C traceparent
+    onto the SyncRun row exactly once, at plan time, so every dispatch across
+    the run's lifecycle -- however many coordinator hops it takes -- parents
+    its span from the same trace as the Python provider-unit work. Uses a
+    bare TracerProvider directly (no global registration) the same way
+    tests/workers/test_worker_job_outbox.py's sibling test does: the context
+    API tracks the current span regardless of which provider produced it, so
+    current_trace_parent()'s propagate.inject() sees it either way."""
+    from opentelemetry.sdk.trace import TracerProvider
+
+    integration = _create_integration(db_session)
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, "commits")
+
+    tracer = TracerProvider().get_tracer("test-sync-planner")
+    with tracer.start_as_current_span("plan-sync-run-under-test") as span:
+        expected_trace_id = format(span.get_span_context().trace_id, "032x")
+        plan = plan_sync_run(
+            db_session,
+            SyncPlanRequest(
+                integration_id=str(integration.id),
+                org_id=ORG_ID,
+                mode=SyncRunMode.INCREMENTAL.value,
+                triggered_by="manual",
+            ),
+        )
+
+    sync_run = db_session.get(SyncRun, plan.sync_run_id)
+    assert sync_run.trace_parent is not None
+    assert expected_trace_id in sync_run.trace_parent
+
+
+def test_plan_sync_run_leaves_trace_parent_null_without_an_active_span(db_session):
+    integration = _create_integration(db_session)
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, "commits")
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+
+    sync_run = db_session.get(SyncRun, plan.sync_run_id)
+    assert sync_run.trace_parent is None
+
+
 def test_plan_sync_run_rejects_plan_over_unit_cap(db_session, monkeypatch):
     """An oversized plan is rejected BEFORE anything is persisted.
 

--- a/tests/test_sync_run_terminal_repair_index_postgres_migration.py
+++ b/tests/test_sync_run_terminal_repair_index_postgres_migration.py
@@ -136,4 +136,4 @@ def test_0101_downgrade_and_application_head_reupgrade_converge(
 
     command.upgrade(_migration_config(), "application_schema@head")
     assert _indexes(migrated_to_0100.engine)[_INDEX] == ("status", "id")
-    assert _revisions(migrated_to_0100.engine) == {"0104"}
+    assert _revisions(migrated_to_0100.engine) == {"0105"}

--- a/tests/test_worker_job_delivery_abandonment_postgres_migration.py
+++ b/tests/test_worker_job_delivery_abandonment_postgres_migration.py
@@ -200,4 +200,4 @@ def test_0099_downgrade_and_reupgrade_converge(
 
     command.upgrade(_migration_config(), "application_schema@head")
     assert sa.inspect(migrated_to_0098.engine).has_table(_TABLE)
-    assert _revisions(migrated_to_0098.engine) == {"0104"}
+    assert _revisions(migrated_to_0098.engine) == {"0105"}

--- a/tests/tooling/test_check_go_integration_coverage.py
+++ b/tests/tooling/test_check_go_integration_coverage.py
@@ -29,4 +29,4 @@ def test_integration_coverage_inventory_completes_and_stays_nonempty() -> None:
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "  RUN  internal/providersync" in result.stdout
-    assert "26 package(s) discovered, 0 denylisted, 26 will run" in result.stdout
+    assert "27 package(s) discovered, 0 denylisted, 27 will run" in result.stdout

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -26,6 +26,7 @@ TEST_GO_CACHE = Path(tempfile.gettempdir()) / "chaos3141-go-sharding-test-cache"
 CHECK_GO_TIMEOUT_SECONDS = 120
 
 EXPECTED_PACKAGES = {
+    "cmd/dev-health-reconciler",
     "cmd/dev-health-worker",
     "cmd/dev-health-workerctl",
     "internal/externalrecompute",
@@ -196,8 +197,8 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
     result = _run_check_go("integration-shard-plan", github_output=github_output)
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "26 package(s) discovered, 0 denylisted, 26 will run" in result.stdout
-    assert "integration shard plan: 3 shard(s), 26 package(s)" in result.stdout
+    assert "27 package(s) discovered, 0 denylisted, 27 will run" in result.stdout
+    assert "integration shard plan: 3 shard(s), 27 package(s)" in result.stdout
 
     output = dict(
         line.split("=", maxsplit=1)
@@ -223,7 +224,7 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
 
     assert set(assignments) == {1, 2, 3}
     flattened = [package for packages in assignments.values() for package in packages]
-    assert len(flattened) == len(set(flattened)) == 26
+    assert len(flattened) == len(set(flattened)) == 27
     assert set(flattened) == EXPECTED_PACKAGES
     assert assignments[1] == {"internal/providersync"}
 
@@ -304,7 +305,7 @@ def test_each_shard_dry_run_executes_only_its_manifest_assignment() -> None:
             if line.startswith("  SHARD-RUN ")
         )
 
-    assert len(selected_packages) == len(set(selected_packages)) == 25
+    assert len(selected_packages) == len(set(selected_packages)) == 26
     assert set(selected_packages) == EXPECTED_PACKAGES - {PROVIDER_PACKAGE}
 
     selected_tests: list[str] = []


### PR DESCRIPTION
## Summary

Propagates trace context through the sync-dispatch coordinator loop for
**Python-planned runs**: dispatch → finalize → post_sync →
reference_discovery, a follow-up to CHAOS-3993 (#1823, merged). PR1 gave
coordinator workers `kind` + `sync_run_id` span attributes but each hop was
its own root span; this PR makes the whole run's coordinator lifecycle one
trace, parented from whatever trace the Python planner was running in when
it called `plan_sync_run`.

Two adjacent trace-propagation points are deliberately NOT covered here —
narrowing the claim rather than growing this diff, per review. Both are
filed as follow-ups (see below): the `sync.team_autoimport` coordinator hop,
and the native Go scheduler's independent `sync_runs` writer
(scheduler-materialized runs, e.g. PagerDuty, still take the NULL path).

- `sync_runs.trace_parent` (nullable, migration 0105) — stamped once at
  plan time in `plan_sync_run` from the active span
  (`dev_health_ops.tracing.current_trace_parent()`, a new shared helper).
- `cmd/dev-health-reconciler`'s `syncDispatchReference` now JOINs
  `sync_dispatch_outbox` → `sync_runs` to resolve `trace_parent` alongside
  org/run identity. NULL decodes to empty string, never an error.
- `TransportArgs` gained an optional `TraceParent` field, carried through
  `Convert`/`matchesReturnedArgs`, deliberately **untagged** for River's
  `ByArgs` uniqueness (two deliveries of the same claim must keep deduping
  regardless of this field).
- `spanForCoordinatorJob` extracts it as a remote parent for all four
  coordinator TransportArgs-embedding workers (dispatch, finalize,
  post_sync, reference_discovery). `sync.team_autoimport` is unchanged
  (`TeamAutoimportJobArgs` doesn't embed `TransportArgs` — out of scope).

## Deploy-order compatibility (decided with evidence, per instruction)

**No two-PR split needed**, unlike CHAOS-3993's outbox envelope. Evidence:

1. `sync_runs.trace_parent` is an additive nullable column — standard
   migrate-then-roll. No reader anywhere requires it populated.
2. `syncDispatchReference`'s Go JOIN already treats NULL as "no trace" (it
   scans into `*string`, only dereferences when non-nil) — old rows read
   fine on new code.
3. `TransportArgs.TraceParent` is untagged for River uniqueness and
   empty-string-safe (`matchesReturnedArgs`, `valid()`) — an old in-flight
   job with no `trace_parent` field decodes to `""` exactly like before.

Nothing here crosses a wire-format agreement two independently-deployed
processes must satisfy simultaneously the way PR1's JSON envelope did — this
is a Go-only reference plus a DB column, not a cross-language contract.

## Migration

`0105_add_sync_run_trace_parent.py` — nullable `TEXT` column on
`sync_runs`, no backfill. `alembic heads` confirms both branch heads
intact (`0066` river_cutover, `0105` application_schema). 9 pin
files / 9 head-assertions updated `0104`→`0105`.

## Tests

- Go: `TestSpanForCoordinatorJobExtractsTraceParent` (in-memory exporter,
  with/without traceparent). New integration test
  `sync_dispatch_reference_integration_test.go` (testcontainers Postgres)
  proves the JOIN itself — nothing upstream type-checks that raw SQL.
- Python: two new tests in `test_sync_planner.py` proving `plan_sync_run`
  actually stamps the active span's trace id onto the row (and leaves it
  NULL with no active span) — closes the gap between "the column exists"
  and "the capture point fires."
- Fixed a Go integration-shard inventory gap the new integration test file
  exposed (`ci/go_integration_shards.tsv` + two hardcoded package-count
  assertions in the sharding/coverage tests) — same class of gap as
  CHAOS-3993's transitional-inventory.json break, different checked-in list.

## Gate tallies

- Go: `go build ./...` rc=0, `gofmt -l .` clean, `go vet ./...` rc=0,
  `go test ./...` rc=0 (56/56 packages).
- Python (`local_validate.sh`, env -u'd against a known shell leak):
  rc=0, 8/8 stages, 13303 passed / 0 failed.
- `check_go.sh integration`: rc=0, 26/26 packages ok.
- `check_go.sh fast`: found and fixed one real regression along the way —
  the live Python planner oracle in `internal/scheduler/sync` loads
  `sync/planner.py` in an isolated synthetic module space with every
  dependency hand-stubbed; this PR's new module-level
  `from dev_health_ops.tracing import current_trace_parent` import had no
  stub, so the oracle died on `ModuleNotFoundError` before ever reaching its
  comparison. Fixed by stubbing it (`current_trace_parent=lambda: None`,
  matching what the real function returns with no active span) — same
  precedented failure class the file already documents for CHAOS-3412's
  watermarks stub. After that fix, the SAME oracle test still fails, but on
  an unrelated jira work-item `processor_flags` parity mismatch between Go's
  scheduler and the Python planner. Reproduced identically on unmodified
  `origin/main` via a throwaway worktree — pre-existing, not touched by this
  diff. Not filed as a ticket yet pending your read (message sent
  separately).

## Codex review (gpt-5.6-luna, xhigh)

Verdict: CHANGES REQUESTED. Dispositions:

- **HIGH** — new integration test seeded a non-UUID `org_id`, which
  `syncDispatchReference` rejects before ever reaching the assertions.
  **Fixed** — seeds a real UUID now, verified against real Postgres
  (`cmd/dev-health-reconciler` package: ok).
- **MEDIUM** — `sync.team_autoimport` doesn't propagate trace_parent.
  **Filed as CHAOS-4014**, not fixed here (narrowed scope, see Summary).
- **MEDIUM** — the native Go scheduler's `sync_runs` writer
  (`materializer.go`) never populates trace_parent.
  **Filed as CHAOS-4015**, not fixed here (narrowed scope, see Summary).
- **LOW** — the traceparent regex validates shape, not semantics (e.g. an
  all-zero trace ID would pass). **Accepted as-is** — OTel's own extraction
  already silently rejects semantically-invalid values into an unparented
  span, and this matches PR1's own regex's identical limitation; a
  divergent, stricter validator here would be inconsistent for no
  correctness gain.
- **LOW** — missing round-trip test coverage for `Convert` → JSON →
  `matchesReturnedArgs` with a *non-empty* TraceParent. **Fixed** —
  `TestPublisherRoundTripsANonEmptyTraceParent` in `runtime_test.go`.

## Follow-ups

- CHAOS-4011 (Normal) — pre-existing `tests/compatibility/river` session-profile
  flake, discovered and cleared as unrelated during CHAOS-3993's CI.
- CHAOS-4014 (Normal) — `sync.team_autoimport` coordinator hop doesn't
  propagate trace context; three-part fix scoped in the ticket.
- CHAOS-4015 (Normal) — the native Go scheduler's `sync_runs` writer never
  populates trace_parent, so scheduler-materialized runs take the NULL path.
