### PR TITLE
ci(go): enable push on all branches for the Go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,43 +1,43 @@
 name: Go
 
 on:
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - '**/*.go'
-  #     - '**/go.mod'
-  #     - '**/go.sum'
-  #     - 'go.work'
-  #     - 'go.work.sum'
-  #     - 'pyproject.toml'
-  #     - 'uv.lock'
-  #     - 'contracts/jobs/v1/**'
-  #     - 'deploy/go-workers/**'
-  #     - 'src/dev_health_ops/licensing/**'
-  #     - 'src/dev_health_ops/metrics/testops*.py'
-  #     - 'src/dev_health_ops/models/**'
-  #     - 'src/dev_health_ops/parsers/**'
-  #     - 'src/dev_health_ops/processors/**'
-  #     - 'src/dev_health_ops/providers/**'
-  #     - 'src/dev_health_ops/storage/repository_rows.py'
-  #     - 'src/dev_health_ops/sync/**'
-  #     - 'src/dev_health_ops/workers/job_contracts/**'
-  #     - 'internal/providersync/testdata/**'
-  #     - 'internal/scheduler/sync/testdata/**'
-  #     - 'tests/workers/job_contracts/**'
-  #     - 'docker/go-worker.Dockerfile'
-  #     - 'tests/compatibility/river/**'
-  #     - 'ci/check_go.sh'
-  #     - 'ci/go_integration_shards.tsv'
-  #     - 'ci/go_providersync_test_shards.tsv'
-  #     - 'ci/requirements-live-python-oracles.txt'
-  #     - 'ci/check_go_containers.sh'
-  #     - 'ci/check_river_compat_static.sh'
-  #     - 'ci/evidence/go-worker-migration/**'
-  #     # - 'ci/local_validate.sh'
-  #     - '.dockerignore'
-  #     - 'Makefile'
-  #     - '.github/workflows/go.yml'
+  push:
+    branches: ['**']
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - 'go.work'
+      - 'go.work.sum'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'contracts/jobs/v1/**'
+      - 'deploy/go-workers/**'
+      - 'src/dev_health_ops/licensing/**'
+      - 'src/dev_health_ops/metrics/testops*.py'
+      - 'src/dev_health_ops/models/**'
+      - 'src/dev_health_ops/parsers/**'
+      - 'src/dev_health_ops/processors/**'
+      - 'src/dev_health_ops/providers/**'
+      - 'src/dev_health_ops/storage/repository_rows.py'
+      - 'src/dev_health_ops/sync/**'
+      - 'src/dev_health_ops/workers/job_contracts/**'
+      - 'internal/providersync/testdata/**'
+      - 'internal/scheduler/sync/testdata/**'
+      - 'tests/workers/job_contracts/**'
+      - 'docker/go-worker.Dockerfile'
+      - 'tests/compatibility/river/**'
+      - 'ci/check_go.sh'
+      - 'ci/go_integration_shards.tsv'
+      - 'ci/go_providersync_test_shards.tsv'
+      - 'ci/requirements-live-python-oracles.txt'
+      - 'ci/check_go_containers.sh'
+      - 'ci/check_river_compat_static.sh'
+      - 'ci/evidence/go-worker-migration/**'
+      # - 'ci/local_validate.sh'
+      - '.dockerignore'
+      - 'Makefile'
+      - '.github/workflows/go.yml'
   pull_request:
     branches: ['**']
     paths:
@@ -77,15 +77,14 @@ on:
       - '.github/workflows/go.yml'
   merge_group:
   workflow_dispatch:
-  # CHAOS-3948: push (above) stays off deliberately -- see the concurrency
-  # block below -- so main got zero Go CI between merges: go.yml only ran on
-  # the PR that introduced a change and on the merge_group queue run, never
-  # again afterward. A scheduled run against main's HEAD (`schedule` always
-  # targets the default branch) closes most of that gap at a fixed cost of
-  # one fan-out a day, which cannot amplify into a merge burst the way `push`
-  # did -- it does not touch the mechanism that exhausted the org's Actions
-  # concurrency. `workflow_dispatch` above also gives a one-click way to run
-  # the full matrix against main on demand between nightly runs.
+  # CHAOS-3948 turned `push` off (see the concurrency block below for why)
+  # and added this scheduled run against main's HEAD (`schedule` always
+  # targets the default branch) as a fixed-cost, one-fan-out-a-day backstop
+  # so main still got some Go CI between merges. Push is enabled again above
+  # (owner-ratified), scoped to all branches like `pull_request`, so a
+  # branch with no open PR also gets gate coverage; this schedule stays as a
+  # cheap safety net regardless. `workflow_dispatch` above also gives a
+  # one-click way to run the full matrix against main on demand.
   schedule:
     - cron: '17 8 * * *'
 
@@ -93,8 +92,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   # PR runs cancel their predecessor so fast-follow pushes don't queue behind
   # a stale diff, which bounds this workflow to ONE live fan-out per PR --
-  # ~13 jobs, several at a 25-minute cap. That bound is why `pull_request` is
-  # the trigger that is on.
+  # ~13 jobs, several at a 25-minute cap.
   #
   # merge_group runs must not be cancelled: a burst of merges lands several
   # within the same `github.ref` group in quick succession, and with an
@@ -103,11 +101,11 @@ concurrency:
   # pass/fail, only "cancelled". integration.yml (push-to-main integration
   # suite) already sets cancel-in-progress: false for the same reason;
   # docs-cloudflare.yml uses this same event-conditional pattern. The same
-  # applies to `on.push`, which is why it stays commented out above: it is
-  # the one trigger here that cannot be cancelled AND fires per-commit, so
-  # it is the one that exhausted the org's Actions concurrency. merge_group
-  # gates the merge itself, so leaving push off costs post-merge re-runs on
-  # main rather than gate coverage.
+  # applies to `on.push`: it is the one trigger here that cannot be
+  # cancelled AND fires per-commit -- CHAOS-3948 turned it off because that
+  # combination exhausted the org's Actions concurrency. It is enabled again
+  # (owner-ratified), scoped by the same path filter `pull_request` uses, so
+  # this risk is worth watching rather than a solved problem.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:


### PR DESCRIPTION
## Summary

Owner-ratified (chris): enable the Go workflow (`go.yml`) on push, for all
branches, so branches without an open PR also get Go CI — not just
`main` (which push was scoped to before CHAOS-3948 turned it off entirely).

## What changed

- `on.push` was fully commented out (previously scoped to `branches: [main]`
  when it was last active). Uncommented, with `branches: ['**']` to match
  `pull_request`'s all-branches pattern, and the identical path filter
  `pull_request` already uses (verbatim, no changes to what paths trigger
  the workflow).
- `pull_request.branches` was already `['**']` — unchanged.
- `merge_group`, `workflow_dispatch`, `schedule` — unchanged.
- `concurrency.group` and `concurrency.cancel-in-progress` — **unchanged**,
  functionally. Only touched the surrounding comments that asserted push
  stays off, since that's no longer true; the historical CHAOS-3948
  reasoning (push is the one trigger here that's both non-cancellable and
  fires per-commit, which is what exhausted the org's Actions concurrency
  before) is preserved in the comments, just reframed as "this risk is
  being re-accepted" rather than "this is why push is off."
- Matrix (jobs) — untouched.

## Verification

- Checked first whether any pinned test asserts the trigger block: neither
  `tests/test_go_live_oracle_ci.py` nor
  `tests/tooling/test_check_go_public_verbs.py` (nor the two other files
  that reference `go.yml`, `tests/tooling/test_go_image_publishing.py` and
  `tests/tooling/test_go_integration_sharding.py`) touch `workflow["on"]` —
  all four ran clean: 19/19 passed.
- `python3 -c "import yaml; ..."` parse check confirms: `push.branches ==
  pull_request.branches == ['**']`, `push.paths == pull_request.paths`,
  `merge_group`/`workflow_dispatch`/`schedule` present and unchanged,
  `concurrency.group`/`concurrency.cancel-in-progress` unchanged verbatim.
- `actionlint .github/workflows/go.yml` — clean, no findings.

No Docker needed for this change.

## Related

- Follow-up (b), making go-quality a required check, is being handled
  separately by chris after this merges.
