### PR TITLE
feat(otel): wire trace_parent injection at outbox-enqueue time (CHAOS-3993 PR2)

### DIFF
--- a/src/dev_health_ops/tracing.py
+++ b/src/dev_health_ops/tracing.py
@@ -249,10 +249,20 @@ def current_trace_parent() -> str | None:
     active span -- tracing disabled, or no request/task span in progress --
     the propagator writes nothing and this returns None, the same as a row
     that predates this field.
+
+    Exactly like Init()'s broad except clause, any failure here -- a bad
+    OTEL_PROPAGATORS value, or anything else the propagator machinery can
+    raise -- is caught and logged as a warning rather than propagated: every
+    caller of this function is on a path (job enqueue, sync-run planning)
+    that must keep working even when tracing itself is broken.
     """
 
-    from opentelemetry.propagate import inject
+    try:
+        from opentelemetry.propagate import inject
 
-    carrier: dict[str, str] = {}
-    inject(carrier)
-    return carrier.get("traceparent")
+        carrier: dict[str, str] = {}
+        inject(carrier)
+        return carrier.get("traceparent")
+    except Exception as exc:
+        logger.warning("failed to capture the active trace parent: %s", exc)
+        return None

--- a/src/dev_health_ops/workers/job_outbox.py
+++ b/src/dev_health_ops/workers/job_outbox.py
@@ -6,12 +6,12 @@ import hashlib
 import json
 from datetime import UTC, datetime
 
-from opentelemetry.propagate import inject
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, SessionTransactionOrigin
 
 from dev_health_ops.models.worker_job_outbox import WorkerJobOutbox
+from dev_health_ops.tracing import current_trace_parent
 
 from .job_contracts import (
     ContractDecodeError,
@@ -70,7 +70,7 @@ def enqueue_worker_job(
             idempotency_key=idempotency_key,
             domain_id=domain_id,
             organization_id=organization_id,
-            trace_parent=_current_trace_parent(),
+            trace_parent=current_trace_parent(),
         )
         if envelope.contract_version not in contract.supported_versions:
             raise ContractDecodeError("unsupported producer contract version")
@@ -119,21 +119,6 @@ def enqueue_worker_job(
             existing, payload.KIND, envelope.contract_version, payload_hash
         )
     return row
-
-
-def _current_trace_parent() -> str | None:
-    """Capture the active span's W3C traceparent, if any, at enqueue time.
-
-    This is how a sync run's Go-side River jobs land in the same trace the
-    Python side started (CHAOS-3993). With no active span -- tracing
-    disabled, or no request/task span in progress -- the propagator writes
-    nothing and this returns None, the same as a producer that predates this
-    field.
-    """
-
-    carrier: dict[str, str] = {}
-    inject(carrier)
-    return carrier.get("traceparent")
 
 
 def _require_migration_route(

--- a/src/dev_health_ops/workers/job_outbox.py
+++ b/src/dev_health_ops/workers/job_outbox.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from datetime import UTC, datetime
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -83,7 +84,7 @@ def enqueue_worker_job(
     existing = _find_existing(session, idempotency_key)
     if existing is not None:
         return _verify_existing(
-            existing, payload.KIND, envelope.contract_version, payload_hash
+            existing, payload.KIND, envelope.contract_version, payload_hash, args
         )
 
     row = WorkerJobOutbox(
@@ -116,7 +117,7 @@ def enqueue_worker_job(
         if existing is None:
             raise OutboxEnqueueError("worker job enqueue conflict") from None
         return _verify_existing(
-            existing, payload.KIND, envelope.contract_version, payload_hash
+            existing, payload.KIND, envelope.contract_version, payload_hash, args
         )
     return row
 
@@ -143,13 +144,25 @@ def _find_existing(session: Session, dedupe_key: str) -> WorkerJobOutbox | None:
 
 
 def _verify_existing(
-    row: WorkerJobOutbox, kind: str, version: int, payload_hash: str
+    row: WorkerJobOutbox,
+    kind: str,
+    version: int,
+    payload_hash: str,
+    args: dict[str, Any],
 ) -> WorkerJobOutbox:
-    if (
-        row.job_kind != kind
-        or row.contract_version != version
-        or row.payload_hash != payload_hash
-    ):
+    if row.job_kind != kind or row.contract_version != version:
+        raise OutboxEnqueueError("dedupe key conflicts with an existing dispatch")
+    if row.payload_hash == payload_hash:
+        return row
+    # payload_hash covers trace_parent (it must, to match what Go actually
+    # relays: internal/joboutbox's terminal-delivery repair matches on it).
+    # But trace_parent is capture-time metadata, not part of a job's logical
+    # identity -- a retry of the same idempotency key from a new
+    # request/task span still has a NEW active span, so a different
+    # trace_parent alone must not read as a conflicting dispatch.
+    if {k: v for k, v in row.args.items() if k != "trace_parent"} != {
+        k: v for k, v in args.items() if k != "trace_parent"
+    }:
         raise OutboxEnqueueError("dedupe key conflicts with an existing dispatch")
     return row
 

--- a/src/dev_health_ops/workers/job_outbox.py
+++ b/src/dev_health_ops/workers/job_outbox.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 from datetime import UTC, datetime
 
+from opentelemetry.propagate import inject
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, SessionTransactionOrigin
@@ -63,20 +64,13 @@ def enqueue_worker_job(
             load_migration_jobs(),
             allow_deferred_route=allow_deferred_route,
         )
-        # trace_parent is NOT wired here yet: this producer's codec supports
-        # it (build_envelope/encode_envelope accept it, contracts/jobs/v1's
-        # schema and fixtures cover it), but actually capturing and passing
-        # it lands in a follow-up PR sequenced strictly after this one
-        # deploys everywhere. Prod is a rolling multi-service restart, so
-        # emitting the field before every Go relay/worker can decode it would
-        # open a window where a live outbox row gets rejected outright
-        # (CHAOS-3993 PR discussion, CHAOS-3990 lane).
         envelope = build_envelope(
             payload,
             correlation_id=correlation_id,
             idempotency_key=idempotency_key,
             domain_id=domain_id,
             organization_id=organization_id,
+            trace_parent=_current_trace_parent(),
         )
         if envelope.contract_version not in contract.supported_versions:
             raise ContractDecodeError("unsupported producer contract version")
@@ -125,6 +119,21 @@ def enqueue_worker_job(
             existing, payload.KIND, envelope.contract_version, payload_hash
         )
     return row
+
+
+def _current_trace_parent() -> str | None:
+    """Capture the active span's W3C traceparent, if any, at enqueue time.
+
+    This is how a sync run's Go-side River jobs land in the same trace the
+    Python side started (CHAOS-3993). With no active span -- tracing
+    disabled, or no request/task span in progress -- the propagator writes
+    nothing and this returns None, the same as a producer that predates this
+    field.
+    """
+
+    carrier: dict[str, str] = {}
+    inject(carrier)
+    return carrier.get("traceparent")
 
 
 def _require_migration_route(

--- a/tests/workers/test_worker_job_outbox.py
+++ b/tests/workers/test_worker_job_outbox.py
@@ -143,20 +143,22 @@ def test_stages_executable_migration_route_without_committing(engine, route: str
         assert verifier.scalar(select(WorkerJobOutbox)) is None
 
 
-def test_enqueue_omits_trace_parent_even_with_an_active_span(engine):
-    # CHAOS-3993 landed the codec's trace_parent support (build_envelope,
-    # encode_envelope, the schema, the fixtures) without wiring it here.
-    # Actually capturing and passing the active span's traceparent is a
-    # follow-up PR sequenced strictly after CHAOS-3993 is deployed
-    # everywhere: prod is a rolling multi-service restart, and emitting the
-    # field before every Go relay/worker can decode it would open a window
-    # where a live outbox row gets rejected outright. This guard makes that
-    # gap a visible, tested fact rather than an implicit one -- when the
-    # follow-up PR wires the injection, this assertion is expected to flip.
+def test_enqueue_captures_active_span_as_trace_parent(engine):
+    # A local (non-global) TracerProvider is enough: start_as_current_span
+    # makes the span current via opentelemetry.context, which is what
+    # inject() reads -- it does not require trace.set_tracer_provider().
     tracer = TracerProvider().get_tracer("test-worker-job-outbox")
     with Session(engine) as session, session.begin():
         with tracer.start_as_current_span("enqueue-under-test"):
             row = _enqueue(session, migration_route="shadow")
+        trace_parent = row.args["trace_parent"]
+        assert trace_parent.startswith("00-")
+        assert trace_parent.count("-") == 3
+
+
+def test_enqueue_without_active_span_omits_trace_parent(engine):
+    with Session(engine) as session, session.begin():
+        row = _enqueue(session, migration_route="shadow")
         assert "trace_parent" not in row.args
 
 

--- a/tests/workers/test_worker_job_outbox.py
+++ b/tests/workers/test_worker_job_outbox.py
@@ -149,11 +149,16 @@ def test_enqueue_captures_active_span_as_trace_parent(engine):
     # inject() reads -- it does not require trace.set_tracer_provider().
     tracer = TracerProvider().get_tracer("test-worker-job-outbox")
     with Session(engine) as session, session.begin():
-        with tracer.start_as_current_span("enqueue-under-test"):
+        with tracer.start_as_current_span("enqueue-under-test") as span:
+            context = span.get_span_context()
+            trace_id = format(context.trace_id, "032x")
+            span_id = format(context.span_id, "016x")
+            flags = format(int(context.trace_flags), "02x")
             row = _enqueue(session, migration_route="shadow")
-        trace_parent = row.args["trace_parent"]
-        assert trace_parent.startswith("00-")
-        assert trace_parent.count("-") == 3
+        # Not just well-formed -- the exact trace/span id and sampled flag
+        # this specific span carried, so a stale or unrelated (but
+        # otherwise valid-shaped) traceparent would fail this.
+        assert row.args["trace_parent"] == f"00-{trace_id}-{span_id}-{flags}"
 
 
 def test_enqueue_without_active_span_omits_trace_parent(engine):
@@ -171,6 +176,32 @@ def test_commit_and_same_content_reuse_return_one_logical_dispatch(engine):
             migration_route="shadow",
         )
         assert second.id == first.id
+
+    with Session(engine) as verifier:
+        assert len(verifier.scalars(select(WorkerJobOutbox)).all()) == 1
+
+
+def test_retry_under_a_different_span_still_reuses_the_same_row(engine):
+    # A retry of the same idempotency key naturally captures a DIFFERENT
+    # trace_parent (a new request/task span each time). trace_parent is
+    # capture-time metadata, not part of a job's logical identity, so this
+    # must still be treated as the same logical dispatch, not a conflict.
+    # Both enqueue calls return the SAME persisted row on reuse, so comparing
+    # their .args after the fact would trivially be equal -- capture each
+    # span's own trace id up front instead, to prove the two attempts were
+    # genuinely under different spans and the second one's trace_parent was
+    # never even compared, let alone required to match.
+    tracer = TracerProvider().get_tracer("test-worker-job-outbox")
+    with Session(engine) as session, session.begin():
+        with tracer.start_as_current_span("first-attempt") as first_span:
+            first_trace_id = format(first_span.get_span_context().trace_id, "032x")
+            first = _enqueue(session, migration_route="shadow")
+        with tracer.start_as_current_span("retry-attempt") as retry_span:
+            retry_trace_id = format(retry_span.get_span_context().trace_id, "032x")
+            second = _enqueue(session, migration_route="shadow")
+        assert retry_trace_id != first_trace_id
+        assert second.id == first.id
+        assert first_trace_id in first.args["trace_parent"]
 
     with Session(engine) as verifier:
         assert len(verifier.scalars(select(WorkerJobOutbox)).all()) == 1


### PR DESCRIPTION
## Summary

CHAOS-3993 PR2 (the deferred second half): wires actual `trace_parent`
capture at Python's worker-outbox enqueue call site. PR1 (#1823, merged)
shipped the codec capability (Go decode, Python encode/decode, schema,
fixtures) without wiring capture, deliberately, so a rolling multi-service
restart couldn't hand an old Go relay/worker a field it didn't know how to
decode. **PR1's decode support is now deployed fleet-wide (confirmed
20:31Z today)**, so this is safe to merge/deploy.

## What changed

- `src/dev_health_ops/workers/job_outbox.py`: `enqueue_worker_job()` now
  passes `trace_parent=current_trace_parent()` into `build_envelope()`.
  Rebased onto CHAOS-3996 (merged, #1826) and deduped: dropped this
  branch's own local `_current_trace_parent()` copy in favor of
  `dev_health_ops.tracing.current_trace_parent()`, the shared helper
  CHAOS-3996 introduced (its docstring already names this call site as an
  intended caller).
- `tests/workers/test_worker_job_outbox.py`: flips the previous
  omission-guard test into a capture-proof test, adds a no-active-span
  omission test.

## Codex review (gpt-5.6-luna, xhigh) — two real bugs found and fixed

**HIGH — trace_parent broke idempotent outbox reuse.**
`payload_hash` (sha256 of the canonical encoded envelope) necessarily
includes `trace_parent` — Go's `internal/joboutbox` terminal-delivery
repair matches a River job's stored metadata `payload_hash` against the
outbox row's, so it has to be the true hash of what was actually relayed.
But `trace_parent` is capture-time metadata (a new span every call), not
part of a job's logical identity. Before the fix, a retry of the same
`idempotency_key` under a different active span raised `"dedupe key
conflicts with an existing dispatch"` instead of transparently reusing the
row — reproduced and confirmed. Fixed: `_verify_existing` now falls back
to comparing the decoded args with `trace_parent` excluded when the bare
hash comparison differs, before concluding a real conflict. New regression
test (`test_retry_under_a_different_span_still_reuses_the_same_row`)
proves reuse still succeeds across two genuinely different spans.

**MEDIUM — OTel misconfiguration could crash every enqueue (and every
sync-run plan).** `current_trace_parent()` (CHAOS-3996's shared helper,
already merged and live) let `opentelemetry.propagate`'s module-level
propagator resolution raise uncaught — reproduced a live `ValueError` with
`OTEL_PROPAGATORS=not-installed-propagator`. This call site had no
`except` around it in either caller (this PR's `job_outbox.py`, or
CHAOS-3996's already-merged `planner.py`), so a tracing misconfiguration
could crash a genuinely unrelated, more critical path. Fixed in
`tracing.py` directly (fixes both callers): wrapped in the same broad
`except Exception` + warning-log pattern `Init()` already uses, so a bad
`OTEL_*` value can never crash core function through this helper either.

**LOW — active-span test only proved shape, not identity.** Tightened
`test_enqueue_captures_active_span_as_trace_parent` to assert the created
span's exact trace id/span id/sampled flag, not just a well-formed
traceparent string.

Codex's clean findings: encoding is sound (Python/Go share the regex,
`build_envelope()` round-trips through encode/decode); standard OTel
injection is cheap and thread-safe; the no-active-span omission test is
meaningful (tracing-disabled/uninstrumented paths are expected in
production); deploy order is safe under the stated premise.

## Verification (no Docker)

- Targeted pytest: `test_worker_job_outbox.py` + `test_sync_planner.py` +
  `job_contracts/` + `test_tracing_metrics.py` — 173 passed, 0 failed, 2
  skipped.
- `ruff format --check` / `ruff check` / `mypy` clean on every touched
  file; full-repo mypy clean via the pre-push hook (2243 files).
- No Go files touched — pure Python diff.

Full local gate (`local_validate.sh`) queues behind the current Docker slot
holder; will run before merge per house rule.
