### PR TITLE
feat(workers): give the Go workers a real CLI mirroring the Celery worker (CHAOS-4020)

### DIFF
--- a/cmd/dev-health-reconciler/main.go
+++ b/cmd/dev-health-reconciler/main.go
@@ -10,11 +10,14 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/platform/shell"
 )
 
+// CHAOS-4005: the reconciler owns the unreclaimable-dispatching sweep. Its
+// --unreclaimable-sweep flag is declared in the platform option registry scoped
+// to this service name (CHAOS-4020), so the flag, its --help entry, its
+// SYNC_UNRECLAIMABLE_SWEEP fallback, and flag > env precedence all follow from
+// one declaration instead of a per-binary opt-in bool.
 var reconcilerSpec = shell.Spec{
 	Service:                         "dev-health-reconciler",
 	ConfigureDependenciesWithLogger: configureReconcilerDependenciesWithLogger,
-	// CHAOS-4005: the reconciler owns the unreclaimable-dispatching sweep.
-	UnreclaimableSweep: true,
 }
 
 func main() {

--- a/deploy/docker-compose/compose.go-workers.yml
+++ b/deploy/docker-compose/compose.go-workers.yml
@@ -7,8 +7,41 @@
 #
 # The checked-in routing contract remains Celery-owned. Starting these
 # containers alone does not transfer a queue or scheduler ownership.
+# CHAOS-4020: worker configuration is flags, not environment.
+#
+# `docker compose config` renders `command:` verbatim, so the deployed
+# configuration of every service below is readable in one place instead of being
+# reconstructed from a host .env file. Each shared flag is defined once as a
+# YAML anchor and referenced per service, so the value has a single source and
+# the rendered output still names it explicitly for every container.
+#
+# `environment:` keeps only credentials. A DSN or a token passed as a process
+# argument is readable through `ps`, `docker inspect`, and this very
+# `docker compose config` output, so those stay in the environment on purpose;
+# `--help` documents them as environment-only.
+x-go-worker-flag:
+  http-addr: &flag-http-addr "--http-addr=:8080"
+  river-schema: &flag-river-schema "--river-schema=${RIVER_DATABASE_SCHEMA:-river}"
+  domain-role: &flag-domain-role "--domain-database-role=${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}"
+  queue-role: &flag-queue-role "--queue-database-role=${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}"
+  queue-mode: &flag-queue-mode "--queue-database-mode=${WORKER_DATABASE_MODE:-session}"
+  coordinator-mode: &flag-coordinator-mode "--coordinator-database-mode=${COORDINATOR_DATABASE_MODE:-session}"
+  domain-pooler: &flag-domain-pooler "--domain-transaction-pooler=${PGBOUNCER_TRANSACTION_MODE:-true}"
+  # The PagerDuty stream runner forwards reconciliation to the Python worker
+  # bridge until the locked-graph port lands (CUT-20), so it cannot open
+  # readiness without a bridge URL.
+  bridge-url: &flag-bridge-url "--operational-bridge-url=${WORKER_OPERATIONAL_BRIDGE_URL:-http://api:8000}"
+  # The default bridge endpoint above is a plaintext Compose service-discovery
+  # name, which the runtime rejects unless this opt-in is set. Override to
+  # false once the bridge is reachable over an internal HTTPS origin.
+  bridge-insecure: &flag-bridge-insecure "--operational-bridge-allow-insecure=${WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE:-true}"
+  # Exactly one runtime owns the PagerDuty webhook stream. Celery keeps it
+  # until the route flips at cutover (CUT-14/18).
+  pagerduty-transport: &flag-pagerduty-transport "--pagerduty-webhook-transport=${PAGERDUTY_WEBHOOK_TRANSPORT:-celery}"
+  log-level: &flag-log-level "--log-level=${LOG_LEVEL:-info}"
+
+# Credentials only. Everything else moved into `command:` above.
 x-go-worker-env-base: &go-worker-env-base
-  DEV_HEALTH_HTTP_ADDR: ":8080"
   POSTGRES_URI: ${POSTGRES_URI:?transaction-pooler domain PostgreSQL URI is required}
   WORKER_DATABASE_URI: ${WORKER_DATABASE_URI:?session-pooler queue-control PostgreSQL URI is required}
   # Port 9000 is the NATIVE protocol, not 8123. Python's CLICKHOUSE_URI speaks
@@ -23,26 +56,7 @@ x-go-worker-env-base: &go-worker-env-base
   # provider-sync handler construction fails closed without it. Shared with the
   # Python services so both runtimes decrypt the same provider credentials.
   SETTINGS_ENCRYPTION_KEY: ${SETTINGS_ENCRYPTION_KEY:?provider credential encryption key is required}
-  RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
-  RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
-  RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
-  WORKER_DATABASE_MODE: ${WORKER_DATABASE_MODE:-session}
-  COORDINATOR_DATABASE_MODE: ${COORDINATOR_DATABASE_MODE:-session}
-  PGBOUNCER_TRANSACTION_MODE: ${PGBOUNCER_TRANSACTION_MODE:-true}
-  # The PagerDuty stream runner forwards reconciliation to the Python
-  # worker bridge until the locked-graph port lands (CUT-20), so it
-  # cannot open readiness without both values.
-  WORKER_OPERATIONAL_BRIDGE_URL: ${WORKER_OPERATIONAL_BRIDGE_URL:-http://api:8000}
   WORKER_OPERATIONAL_BRIDGE_TOKEN: ${WORKER_OPERATIONAL_BRIDGE_TOKEN:-}
-  # The default endpoint above is a plaintext Compose service-discovery
-  # name, which the runtime rejects unless this opt-in is set: without it
-  # the PagerDuty runner can never construct its bridge handler. Override
-  # to "false" once the bridge is reachable over an internal HTTPS origin.
-  WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE: ${WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE:-true}
-  # Exactly one runtime owns the PagerDuty webhook stream. Celery keeps
-  # it until the route flips at cutover (CUT-14/18).
-  PAGERDUTY_WEBHOOK_TRANSPORT: ${PAGERDUTY_WEBHOOK_TRANSPORT:-celery}
-  DEV_HEALTH_LOG_LEVEL: ${LOG_LEVEL:-info}
   AUTO_RUN_MIGRATIONS: "false"
 
 services:
@@ -172,6 +186,17 @@ services:
       - --queue-concurrency=investment=1,metrics=2,reports=2,workgraph=1
       - --worker-group=heavy
       - --shutdown-timeout=7260s
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     environment: &go-worker-env
       <<: *go-worker-env-base
     networks: [dev-health]
@@ -194,6 +219,17 @@ services:
       - --queue-concurrency=coverage=1,heartbeat=1,retention=1,webhooks=4
       - --worker-group=ops
       - --shutdown-timeout=960s
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     environment:
       <<: *go-worker-env-base
     stop_grace_period: 960s
@@ -209,6 +245,17 @@ services:
       - --queue-concurrency=sync=4
       - --worker-group=sync
       - --shutdown-timeout=960s
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     environment:
       <<: *go-worker-env-base
     stop_grace_period: 960s
@@ -231,6 +278,17 @@ services:
       - --queue-concurrency=sync_provider=2
       - --worker-group=sync-provider
       - --shutdown-timeout=960s
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     environment:
       <<: *go-worker-env-base
     stop_grace_period: 960s
@@ -240,10 +298,21 @@ services:
     image: ${DEV_HEALTH_GO_RECONCILER_IMAGE:-ghcr.io/full-chaos/dev-health-go-reconciler:latest}
     labels:
       dev-health.io/worker-group: reconciler
-    command: []
+    command:
+      - --shutdown-timeout=60s
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     environment:
       <<: *go-worker-env-base
-      DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s
       COORDINATOR_DATABASE_URI: ${COORDINATOR_DATABASE_URI:?session-pooler coordinator PostgreSQL URI is required}
     stop_grace_period: 60s
 
@@ -252,10 +321,21 @@ services:
     image: ${DEV_HEALTH_GO_SCHEDULER_IMAGE:-ghcr.io/full-chaos/dev-health-go-scheduler:latest}
     labels:
       dev-health.io/worker-group: scheduler
-    command: []
+    command:
+      - --shutdown-timeout=60s
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     environment:
       <<: *go-worker-env-base
-      DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s
       COORDINATOR_DATABASE_URI: ${COORDINATOR_DATABASE_URI:?session-pooler coordinator PostgreSQL URI is required}
     stop_grace_period: 60s
 
@@ -264,11 +344,22 @@ services:
     image: ${DEV_HEALTH_GO_STREAM_RUNNER_IMAGE:-ghcr.io/full-chaos/dev-health-go-stream-runner:latest}
     labels:
       dev-health.io/worker-group: stream-external
-    command: []
+    command:
+      - --profile=external
+      - --shutdown-timeout=60s
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     environment:
       <<: *go-worker-env-base
-      DEV_HEALTH_PROFILE: external
-      DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s
     stop_grace_period: 60s
 
   go-stream-ingest:
@@ -276,11 +367,22 @@ services:
     image: ${DEV_HEALTH_GO_STREAM_RUNNER_IMAGE:-ghcr.io/full-chaos/dev-health-go-stream-runner:latest}
     labels:
       dev-health.io/worker-group: stream-ingest
-    command: []
+    command:
+      - --profile=ingest
+      - --shutdown-timeout=60s
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     environment:
       <<: *go-worker-env-base
-      DEV_HEALTH_PROFILE: ingest
-      DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s
     stop_grace_period: 60s
 
   # PagerDuty webhook delivery is independently routable from dataset sync, so
@@ -290,9 +392,20 @@ services:
     image: ${DEV_HEALTH_GO_STREAM_RUNNER_IMAGE:-ghcr.io/full-chaos/dev-health-go-stream-runner:latest}
     labels:
       dev-health.io/worker-group: stream-pagerduty
-    command: []
+    command:
+      - --profile=pagerduty
+      - --shutdown-timeout=60s
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     environment:
       <<: *go-worker-env-base
-      DEV_HEALTH_PROFILE: pagerduty
-      DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s
     stop_grace_period: 60s

--- a/deploy/docker-swarm/stack.go-workers.yml
+++ b/deploy/docker-swarm/stack.go-workers.yml
@@ -1,14 +1,41 @@
 # Additive Swarm topology. Deploy it with stack.yml as a second config file;
 # all replicas start at zero, so this is inert until an operator scales a
 # reviewed worker group. The base stack keeps Celery, Beat, and Valkey DB 0.
+# One definition per shared flag; every service references these so a value has
+# a single source and the rendered command still names it explicitly.
+x-go-worker-flag:
+  http-addr: &flag-http-addr "--http-addr=:8080"
+  river-schema: &flag-river-schema "--river-schema=${RIVER_DATABASE_SCHEMA:-river}"
+  domain-role: &flag-domain-role "--domain-database-role=${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}"
+  queue-role: &flag-queue-role "--queue-database-role=${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}"
+  queue-mode: &flag-queue-mode "--queue-database-mode=${WORKER_DATABASE_MODE:-session}"
+  coordinator-mode: &flag-coordinator-mode "--coordinator-database-mode=${COORDINATOR_DATABASE_MODE:-session}"
+  domain-pooler: &flag-domain-pooler "--domain-transaction-pooler=${PGBOUNCER_TRANSACTION_MODE:-true}"
+  # The PagerDuty stream runner forwards reconciliation to the Python worker
+  # bridge until the locked-graph port lands (CUT-20), so it cannot open
+  # readiness without a bridge URL.
+  bridge-url: &flag-bridge-url "--operational-bridge-url=${WORKER_OPERATIONAL_BRIDGE_URL:-http://api:8000}"
+  # The default endpoint above is a plaintext Swarm service-discovery name,
+  # which the runtime rejects unless this opt-in is set. Override to false once
+  # the bridge is reachable over an internal HTTPS origin.
+  bridge-insecure: &flag-bridge-insecure "--operational-bridge-allow-insecure=${WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE:-true}"
+  # Exactly one runtime owns the PagerDuty webhook stream. Celery keeps it
+  # until the route flips at cutover (CUT-14/18).
+  pagerduty-transport: &flag-pagerduty-transport "--pagerduty-webhook-transport=${PAGERDUTY_WEBHOOK_TRANSPORT:-celery}"
+  log-level: &flag-log-level "--log-level=${LOG_LEVEL:-info}"
+
 x-go-worker: &go-worker
   image: ${DEV_HEALTH_GO_WORKER_IMAGE:-ghcr.io/full-chaos/dev-health-go-worker:latest}
   read_only: true
   user: "65532:65532"
   security_opt: [no-new-privileges:true]
   tmpfs: [/tmp]
+  # CHAOS-4020: worker configuration is flags, not environment. Each shared
+  # flag is defined once below and referenced per service, so `docker stack
+  # config` renders the deployed configuration of every service explicitly.
+  # `environment:` keeps only credentials: a DSN or token in `command:` would
+  # be visible to `ps` and `docker inspect`.
   environment: &go-worker-env-base
-    DEV_HEALTH_HTTP_ADDR: ":8080"
     POSTGRES_URI: ${POSTGRES_URI:?transaction-pooler domain PostgreSQL URI is required}
     WORKER_DATABASE_URI: ${WORKER_DATABASE_URI:?session-pooler queue-control PostgreSQL URI is required}
     # Native protocol (9000), not HTTP (8123): the Go worker's ClickHouse
@@ -19,26 +46,7 @@ x-go-worker: &go-worker
     # deploy/go-workers/deployment.json requires this for the sync group, and
     # provider-sync handler construction fails closed without it.
     SETTINGS_ENCRYPTION_KEY: ${SETTINGS_ENCRYPTION_KEY:?provider credential encryption key is required}
-    RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
-    RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
-    RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
-    # The PagerDuty stream runner forwards reconciliation to the Python
-    # worker bridge until the locked-graph port lands (CUT-20), so it
-    # cannot open readiness without both values.
-    WORKER_OPERATIONAL_BRIDGE_URL: ${WORKER_OPERATIONAL_BRIDGE_URL:-http://api:8000}
     WORKER_OPERATIONAL_BRIDGE_TOKEN: ${WORKER_OPERATIONAL_BRIDGE_TOKEN:-}
-    # The default endpoint above is a plaintext Swarm service-discovery name,
-    # which the runtime rejects unless this opt-in is set: without it the
-    # PagerDuty runner can never construct its bridge handler. Override to
-    # "false" once the bridge is reachable over an internal HTTPS origin.
-    WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE: ${WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE:-true}
-    # Exactly one runtime owns the PagerDuty webhook stream. Celery keeps
-    # it until the route flips at cutover (CUT-14/18).
-    PAGERDUTY_WEBHOOK_TRANSPORT: ${PAGERDUTY_WEBHOOK_TRANSPORT:-celery}
-    WORKER_DATABASE_MODE: ${WORKER_DATABASE_MODE:-session}
-    COORDINATOR_DATABASE_MODE: ${COORDINATOR_DATABASE_MODE:-session}
-    PGBOUNCER_TRANSACTION_MODE: ${PGBOUNCER_TRANSACTION_MODE:-true}
-    DEV_HEALTH_LOG_LEVEL: ${LOG_LEVEL:-info}
     AUTO_RUN_MIGRATIONS: "false"
   networks: [dev-health-internal]
   deploy: &go-worker-deploy
@@ -67,19 +75,64 @@ services:
     <<: *go-worker
     labels:
       dev-health.io/worker-group: heavy
-    command: ["--queues=investment,metrics,reports,workgraph", "--queue-concurrency=investment=1,metrics=2,reports=2,workgraph=1", "--worker-group=heavy", "--shutdown-timeout=7260s"]
+    command:
+      - "--queues=investment,metrics,reports,workgraph"
+      - "--queue-concurrency=investment=1,metrics=2,reports=2,workgraph=1"
+      - "--worker-group=heavy"
+      - "--shutdown-timeout=7260s"
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     stop_grace_period: 7260s
   go-worker-ops:
     <<: *go-worker
     labels:
       dev-health.io/worker-group: ops
-    command: ["--queues=coverage,heartbeat,retention,webhooks", "--queue-concurrency=coverage=1,heartbeat=1,retention=1,webhooks=4", "--worker-group=ops", "--shutdown-timeout=960s"]
+    command:
+      - "--queues=coverage,heartbeat,retention,webhooks"
+      - "--queue-concurrency=coverage=1,heartbeat=1,retention=1,webhooks=4"
+      - "--worker-group=ops"
+      - "--shutdown-timeout=960s"
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     stop_grace_period: 960s
   go-worker-sync:
     <<: *go-worker
     labels:
       dev-health.io/worker-group: sync
-    command: ["--queues=sync", "--queue-concurrency=sync=4", "--worker-group=sync", "--shutdown-timeout=960s"]
+    command:
+      - "--queues=sync"
+      - "--queue-concurrency=sync=4"
+      - "--worker-group=sync"
+      - "--shutdown-timeout=960s"
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     stop_grace_period: 960s
   # Split from the sync worker: a combined service cannot start while provider
   # routes are default-off (CHAOS-3926). See compose.go-workers.yml.
@@ -87,16 +140,43 @@ services:
     <<: *go-worker
     labels:
       dev-health.io/worker-group: sync-provider
-    command: ["--queues=sync_provider", "--queue-concurrency=sync_provider=2", "--worker-group=sync-provider", "--shutdown-timeout=960s"]
+    command:
+      - "--queues=sync_provider"
+      - "--queue-concurrency=sync_provider=2"
+      - "--worker-group=sync-provider"
+      - "--shutdown-timeout=960s"
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     stop_grace_period: 960s
   go-reconciler:
     <<: *go-worker
     image: ${DEV_HEALTH_GO_RECONCILER_IMAGE:-ghcr.io/full-chaos/dev-health-go-reconciler:latest}
     labels:
       dev-health.io/worker-group: reconciler
+    command:
+      - "--shutdown-timeout=60s"
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     environment:
       <<: *go-worker-env-base
-      DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s
       COORDINATOR_DATABASE_URI: "${COORDINATOR_DATABASE_URI:?session-pooler coordinator PostgreSQL URI is required}"
     stop_grace_period: 60s
   go-scheduler:
@@ -104,9 +184,21 @@ services:
     image: ${DEV_HEALTH_GO_SCHEDULER_IMAGE:-ghcr.io/full-chaos/dev-health-go-scheduler:latest}
     labels:
       dev-health.io/worker-group: scheduler
+    command:
+      - "--shutdown-timeout=60s"
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
     environment:
       <<: *go-worker-env-base
-      DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s
       COORDINATOR_DATABASE_URI: "${COORDINATOR_DATABASE_URI:?session-pooler coordinator PostgreSQL URI is required}"
     stop_grace_period: 60s
   go-stream-external:
@@ -114,19 +206,64 @@ services:
     image: ${DEV_HEALTH_GO_STREAM_RUNNER_IMAGE:-ghcr.io/full-chaos/dev-health-go-stream-runner:latest}
     labels:
       dev-health.io/worker-group: stream-external
-    environment: {<<: *go-worker-env-base, DEV_HEALTH_PROFILE: external, DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s}
+    command:
+      - "--profile=external"
+      - "--shutdown-timeout=60s"
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
+    environment:
+      <<: *go-worker-env-base
     stop_grace_period: 60s
   go-stream-ingest:
     <<: *go-worker
     image: ${DEV_HEALTH_GO_STREAM_RUNNER_IMAGE:-ghcr.io/full-chaos/dev-health-go-stream-runner:latest}
     labels:
       dev-health.io/worker-group: stream-ingest
-    environment: {<<: *go-worker-env-base, DEV_HEALTH_PROFILE: ingest, DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s}
+    command:
+      - "--profile=ingest"
+      - "--shutdown-timeout=60s"
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
+    environment:
+      <<: *go-worker-env-base
     stop_grace_period: 60s
   go-stream-pagerduty:
     <<: *go-worker
     image: ${DEV_HEALTH_GO_STREAM_RUNNER_IMAGE:-ghcr.io/full-chaos/dev-health-go-stream-runner:latest}
     labels:
       dev-health.io/worker-group: stream-pagerduty
-    environment: {<<: *go-worker-env-base, DEV_HEALTH_PROFILE: pagerduty, DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s}
+    command:
+      - "--profile=pagerduty"
+      - "--shutdown-timeout=60s"
+      - *flag-http-addr
+      - *flag-river-schema
+      - *flag-domain-role
+      - *flag-queue-role
+      - *flag-queue-mode
+      - *flag-coordinator-mode
+      - *flag-domain-pooler
+      - *flag-bridge-url
+      - *flag-bridge-insecure
+      - *flag-pagerduty-transport
+      - *flag-log-level
+    environment:
+      <<: *go-worker-env-base
     stop_grace_period: 60s

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -382,19 +382,27 @@ be served by the handlers it actually constructed. A deployment that selects
 both queues; a worker that selects only `sync` must not claim `sync_provider`.
 The same exact queue and handler checks apply to every group.
 
-Use `--queues`, `--queue-concurrency`, `--worker-group`, and
+Use `-Q/--queues`, `-c/--concurrency`, `--worker-group`, and
 `--shutdown-timeout` to declare the process topology. Do not use a named worker
 preset or rely on a service name to select queues. The process reports the
 canonical queue set, per-queue concurrency, worker identity, one River client,
 and effective database limits in its startup and readiness evidence.
 
-The `sync.team_autoimport` handler still needs
-`WORKER_OPERATIONAL_BRIDGE_URL` and `WORKER_OPERATIONAL_BRIDGE_TOKEN` when the
-selected queue requires that bridge. The constructor fails closed on an empty
-origin or token. If the origin is plain HTTP rather than HTTPS, also set
-`WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE=true`, matching the deployment
-examples. These settings are dependency requirements for the selected queue;
-they are not queue-selection aliases.
+Since CHAOS-4020 the same is true of the *rest* of the configuration: run
+`dev-health-worker --help` for the full option list, the environment variable
+each flag falls back to, and its default. Resolution is flag > environment >
+default, an unknown flag is rejected at startup with exit status 2, and the
+manifests in this directory pass their configuration in `command:` so
+`docker compose config` shows what each container actually runs.
+
+The `sync.team_autoimport` handler still needs an operational bridge when the
+selected queue requires it: pass `--operational-bridge-url` and set
+`WORKER_OPERATIONAL_BRIDGE_TOKEN` in the environment (the token is a credential
+and has no flag). The constructor fails closed on an empty origin or token. If
+the origin is plain HTTP rather than HTTPS, also pass
+`--operational-bridge-allow-insecure=true`, matching the deployment examples.
+These settings are dependency requirements for the selected queue; they are not
+queue-selection aliases.
 
 ### Provider credentials the Go executor can decrypt
 

--- a/deploy/helm/dev-health/templates/go-workers.yaml
+++ b/deploy/helm/dev-health/templates/go-workers.yaml
@@ -40,29 +40,49 @@ spec:
         - name: {{ $group.name }}
           image: {{ $group.image }}
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
-          {{- if $group.queues }}
-          {{- $parts := list }}
-          {{- range $queue := $group.queues }}
-          {{- $parts = append $parts (printf "%s=%v" $queue (index $group.queueConcurrency $queue)) }}
-          {{- end }}
+          # CHAOS-4020: worker configuration is flags. Every setting a Go
+          # binary reads that is not a credential is rendered here, so
+          # `helm template` and `kubectl describe` show the deployed
+          # configuration in one place instead of spreading it across a
+          # ConfigMap, a Secret, and per-group env. Credentials stay in env:
+          # an argument is visible to anyone who can read the pod spec.
           args:
+            {{- if $group.queues }}
+            {{- $parts := list }}
+            {{- range $queue := $group.queues }}
+            {{- $parts = append $parts (printf "%s=%v" $queue (index $group.queueConcurrency $queue)) }}
+            {{- end }}
             - {{ printf "--queues=%s" (join "," $group.queues) | quote }}
             - {{ printf "--queue-concurrency=%s" (join "," $parts) | quote }}
             - {{ printf "--worker-group=%s" $group.name | quote }}
-            - {{ printf "--shutdown-timeout=%ds" (int $group.terminationGracePeriodSeconds) | quote }}
-          {{- end }}
-          env:
-            {{- if $group.runtimeProfile }}
-            - {name: DEV_HEALTH_PROFILE, value: {{ $group.runtimeProfile | quote }}}
             {{- end }}
-            - {name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}
+            {{- with $group.runtimeProfile }}
+            - {{ printf "--profile=%s" . | quote }}
+            {{- end }}
+            - {{ printf "--shutdown-timeout=%ds" (int $group.terminationGracePeriodSeconds) | quote }}
+            - "--http-addr=:8080"
+            {{- if $.Values.goWorkers.pgbouncer.enabled }}
+            - "--domain-transaction-pooler=true"
+            - "--queue-database-mode=session"
+            {{- if $coordinator }}
+            - "--coordinator-database-mode=session"
+            {{- end }}
+            {{- end }}
+            {{- /*
+              Per-group only, deliberately. A chart-wide extraArgs would append
+              every flag to every group, and options are scoped per binary --
+              --unreclaimable-sweep is reconciler-only, so a global entry would
+              make the worker, scheduler, and stream-runner pods exit 2 on an
+              unknown flag. Scope the flag to the group that accepts it.
+            */}}
+            {{- with $group.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
             {{- with (include "dev-health.goWorkerClickhouseURI" $) }}
             # Explicit env beats the shared Secret mounted via envFrom below,
             # so Go pods get the native port while Python keeps HTTP.
             - {name: CLICKHOUSE_URI, value: {{ . | quote }}}
-            {{- end }}
-            {{- if not $group.queues }}
-            - {name: DEV_HEALTH_SHUTDOWN_TIMEOUT, value: {{ printf "%ds" (int $group.terminationGracePeriodSeconds) | quote }}}
             {{- end }}
             {{- if $.Values.goWorkers.pgbouncer.enabled }}
             # Every Go worker group uses the bounded domain transaction pool plus
@@ -70,14 +90,11 @@ spec:
             # the separate coordinator lock session endpoint.
             - name: POSTGRES_URI
               valueFrom: {secretKeyRef: {name: {{ include "dev-health.goPgbouncerSecretName" $ }}, key: POSTGRES_URI}}
-            - {name: PGBOUNCER_TRANSACTION_MODE, value: "true"}
             - name: WORKER_DATABASE_URI
               valueFrom: {secretKeyRef: {name: {{ include "dev-health.goPgbouncerSecretName" $ }}, key: WORKER_DATABASE_URI}}
-            - {name: WORKER_DATABASE_MODE, value: session}
             {{- if $coordinator }}
             - name: COORDINATOR_DATABASE_URI
               valueFrom: {secretKeyRef: {name: {{ include "dev-health.goPgbouncerSecretName" $ }}, key: COORDINATOR_DATABASE_URI}}
-            - {name: COORDINATOR_DATABASE_MODE, value: session}
             {{- end }}
             {{- end }}
           envFrom:

--- a/deploy/kubernetes/go-workers.yaml
+++ b/deploy/kubernetes/go-workers.yaml
@@ -49,8 +49,7 @@ spec:
       containers:
         - name: worker
           image: ghcr.io/full-chaos/dev-health-go-worker:latest
-          args: ["--queues=investment,metrics,reports,workgraph", "--queue-concurrency=investment=1,metrics=2,reports=2,workgraph=1", "--worker-group=heavy", "--shutdown-timeout=7260s"]
-          env: [{name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}]
+          args: ["--queues=investment,metrics,reports,workgraph", "--queue-concurrency=investment=1,metrics=2,reports=2,workgraph=1", "--worker-group=heavy", "--shutdown-timeout=7260s", "--http-addr=:8080"]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}, {secretRef: {name: dev-health-go-worker-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
@@ -76,8 +75,7 @@ spec:
       containers:
         - name: worker
           image: ghcr.io/full-chaos/dev-health-go-worker:latest
-          args: ["--queues=coverage,heartbeat,retention,webhooks", "--queue-concurrency=coverage=1,heartbeat=1,retention=1,webhooks=4", "--worker-group=ops", "--shutdown-timeout=960s"]
-          env: [{name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}]
+          args: ["--queues=coverage,heartbeat,retention,webhooks", "--queue-concurrency=coverage=1,heartbeat=1,retention=1,webhooks=4", "--worker-group=ops", "--shutdown-timeout=960s", "--http-addr=:8080"]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}, {secretRef: {name: dev-health-go-worker-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
@@ -103,8 +101,7 @@ spec:
       containers:
         - name: worker
           image: ghcr.io/full-chaos/dev-health-go-worker:latest
-          args: ["--queues=sync", "--queue-concurrency=sync=4", "--worker-group=sync", "--shutdown-timeout=960s"]
-          env: [{name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}]
+          args: ["--queues=sync", "--queue-concurrency=sync=4", "--worker-group=sync", "--shutdown-timeout=960s", "--http-addr=:8080"]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}, {secretRef: {name: dev-health-go-worker-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
@@ -130,8 +127,7 @@ spec:
       containers:
         - name: worker
           image: ghcr.io/full-chaos/dev-health-go-worker:latest
-          args: ["--queues=sync_provider", "--queue-concurrency=sync_provider=2", "--worker-group=sync-provider", "--shutdown-timeout=960s"]
-          env: [{name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}]
+          args: ["--queues=sync_provider", "--queue-concurrency=sync_provider=2", "--worker-group=sync-provider", "--shutdown-timeout=960s", "--http-addr=:8080"]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}, {secretRef: {name: dev-health-go-worker-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
@@ -154,7 +150,7 @@ spec:
       containers:
         - name: reconciler
           image: ghcr.io/full-chaos/dev-health-go-reconciler:latest
-          env: [{name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}, {name: DEV_HEALTH_SHUTDOWN_TIMEOUT, value: 60s}]
+          args: ["--shutdown-timeout=60s", "--http-addr=:8080"]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}, {secretRef: {name: dev-health-go-worker-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
@@ -177,7 +173,7 @@ spec:
       containers:
         - name: scheduler
           image: ghcr.io/full-chaos/dev-health-go-scheduler:latest
-          env: [{name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}, {name: DEV_HEALTH_SHUTDOWN_TIMEOUT, value: 60s}]
+          args: ["--shutdown-timeout=60s", "--http-addr=:8080"]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}, {secretRef: {name: dev-health-go-worker-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
@@ -200,7 +196,7 @@ spec:
       containers:
         - name: stream-runner
           image: ghcr.io/full-chaos/dev-health-go-stream-runner:latest
-          env: [{name: DEV_HEALTH_PROFILE, value: external}, {name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}, {name: DEV_HEALTH_SHUTDOWN_TIMEOUT, value: 60s}]
+          args: ["--profile=external", "--shutdown-timeout=60s", "--http-addr=:8080"]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}, {secretRef: {name: dev-health-go-worker-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
@@ -223,7 +219,7 @@ spec:
       containers:
         - name: stream-runner
           image: ghcr.io/full-chaos/dev-health-go-stream-runner:latest
-          env: [{name: DEV_HEALTH_PROFILE, value: ingest}, {name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}, {name: DEV_HEALTH_SHUTDOWN_TIMEOUT, value: 60s}]
+          args: ["--profile=ingest", "--shutdown-timeout=60s", "--http-addr=:8080"]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}, {secretRef: {name: dev-health-go-worker-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
@@ -246,7 +242,7 @@ spec:
       containers:
         - name: stream-runner
           image: ghcr.io/full-chaos/dev-health-go-stream-runner:latest
-          env: [{name: DEV_HEALTH_PROFILE, value: pagerduty}, {name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}, {name: DEV_HEALTH_SHUTDOWN_TIMEOUT, value: 60s}]
+          args: ["--profile=pagerduty", "--shutdown-timeout=60s", "--http-addr=:8080"]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}, {secretRef: {name: dev-health-go-worker-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}

--- a/docs/operate/run/workers-and-jobs.md
+++ b/docs/operate/run/workers-and-jobs.md
@@ -42,24 +42,81 @@ dev-hops workers start-worker \
 ### Start a Go worker group
 
 `dev-health-worker` requires an explicit, static set of registered queues. The
-deployment passes process topology as command arguments. Queue and concurrency
-arguments may be comma-separated or repeated. The process sorts and validates
-the set before readiness and constructs one River client for all selected
-queues.
+deployment passes its whole configuration as command arguments. Queue and
+concurrency arguments may be comma-separated or repeated. The process sorts and
+validates the set before readiness and constructs one River client for all
+selected queues.
 
 ```bash
 dev-health-worker \
-  --queues sync,sync_provider \
-  --queue-concurrency sync=4,sync_provider=2 \
+  -Q sync,sync_provider \
+  -c sync=4,sync_provider=2 \
   --worker-group sync \
   --shutdown-timeout 960s
 ```
 
-`--queues` is the only way to select queues; there is no environment fallback
-for it. `DEV_HEALTH_QUEUE_CONCURRENCY`, `DEV_HEALTH_WORKER_GROUP`, and
-`DEV_HEALTH_SHUTDOWN_TIMEOUT` remain supported as fallbacks for existing
-supervisors. Do not set one of those together with its command argument;
-ambiguous input fails before readiness.
+The flag surface mirrors the Python Celery worker CLI: `-Q/--queues` names the
+queues to consume and `-c/--concurrency` sets the worker budget, exactly as
+`celery -A dev_health_ops.workers.celery_app worker -Q … --concurrency=…` does
+for the Celery fleet. `-q` and `--loglevel` are accepted as aliases.
+
+**The two fleets do not serve the same queues.** `-Q` names queues from the Go
+River topology (`coverage`, `heartbeat`, `investment`, `metrics`, `reports`,
+`retention`, `sync`, `sync_provider`, `webhooks`, `workgraph`). Four of those
+names — `metrics`, `reports`, `sync`, `webhooks` — are shared with the Celery
+app and mean the same thing; the rest exist in only one runtime. Selecting a
+queue this fleet does not serve fails before readiness, because startup
+validation requires the selected queue set to equal the constructed handler
+set.
+
+**`--help` is the discovery surface.** Run `dev-health-worker --help` for the
+complete option list: every flag, the environment variable it falls back to,
+and its default, grouped by purpose. The reconciler, scheduler, and stream
+runner print the options *they* accept, so a binary never advertises a setting
+it ignores.
+
+Resolution order is **flag > environment > default**. Every option except the
+credentials below may be given either way; the flag wins when both are present,
+and the process logs one warning at startup naming any setting that arrived
+through the environment. `--queues` has no environment fallback: every deploy artifact passes it.
+
+An **unknown flag is rejected before the process starts** (exit status 2). This
+is the property an environment variable cannot offer: a misspelled variable
+name is indistinguishable from an unset one and stays silently inert, which is
+how a typo'd `OTEL_SERVICE_NAMEi` survived unnoticed in production.
+
+`-c` is the canonical short form of `--concurrency`, matching Celery;
+`--queue-concurrency` remains accepted as a deprecated alias so supervisors
+outside this repository keep working.
+
+#### Provider route switches stay in the environment
+
+The forty `WORKER_<PROVIDER>_<DATASET>_ENABLED` switches are **not** on the CLI
+and deliberately have no flag. What a worker executes follows from the queues it
+subscribes to; a parallel forty-switch enablement surface does not scale, and it
+is the thing being designed away.
+
+They remain as environment variables because the Python planner reads the
+identical names through `ProviderUnitRouteSwitches` to decide what to *plan*.
+Producer and executor must agree: a planner that emits units for a route no
+executor serves is the wedge shape CHAOS-3990 exists to prevent. `GO_PROVIDER_ROUTES=all`
+(local only, requires `DEV_HEALTH_ENV=local`) is unchanged.
+
+#### What stays in the environment
+
+Credentials only, and deliberately. A DSN or token passed as a process argument
+is readable through `ps`, `docker inspect`, and `docker compose config`, so
+these ten have no flag and `--help` documents them as environment-only:
+
+`POSTGRES_URI`, `WORKER_DATABASE_URI`, `COORDINATOR_DATABASE_URI`,
+`CLICKHOUSE_URI`, `VALKEY_URI`, `SETTINGS_ENCRYPTION_KEY`,
+`SETTINGS_ENCRYPTION_SALT`, `PAGER_DUTY_CLIENT_ID`, `PAGER_DUTY_SECRET`,
+`WORKER_OPERATIONAL_BRIDGE_TOKEN`.
+
+Everything else a Go worker reads is a flag, and the shipped Compose, Swarm,
+Kubernetes, and Helm surfaces pass it in `command:`/`args:` — so
+`docker compose config` and `kubectl describe pod` show the deployed
+configuration in one place instead of a merged environment map.
 
 The deployment owns the worker group name, replicas, resources, autoscaling,
 shutdown budget, and per-queue concurrency. The binary owns neither a named

--- a/docs/reference/configuration/environment.md
+++ b/docs/reference/configuration/environment.md
@@ -55,6 +55,33 @@ The API and sync workers need the same app client values. The redirect URI is th
 
 ## Worker and schedule settings
 
+!!! note "Go workers are configured by flags first (CHAOS-4020)"
+
+    The Go worker binaries (`dev-health-worker`, `dev-health-reconciler`,
+    `dev-health-scheduler`, `dev-health-stream-runner`) resolve every setting
+    that has a flag **flag > environment > default**. The forty
+    `WORKER_*_ENABLED` provider route switches and the `OTEL_*` variables have
+    no flag and stay environment-only. `--help` is their single discovery
+    surface: it lists each flag with the environment variable it falls back to
+    and its default, so this page is a reference for the fallback names rather
+    than the way to find an option.
+
+    The environment names below remain supported and are unchanged — the
+    Python producer reads the same `WORKER_*_ENABLED` route switches, so
+    renaming them would split producer and executor. What changed is that the
+    shipped Compose, Swarm, Kubernetes, and Helm surfaces now pass the
+    flag-backed settings in `command:`/`args:`, and an unknown flag is rejected
+    at startup instead of a misspelled variable sitting inert.
+
+    Ten credentials have **no** flag and must stay in the environment, because
+    a process argument is readable through `ps` and `docker inspect`:
+    `POSTGRES_URI`, `WORKER_DATABASE_URI`, `COORDINATOR_DATABASE_URI`,
+    `CLICKHOUSE_URI`, `VALKEY_URI`, `SETTINGS_ENCRYPTION_KEY`,
+    `SETTINGS_ENCRYPTION_SALT`, `PAGER_DUTY_CLIENT_ID`, `PAGER_DUTY_SECRET`,
+    `WORKER_OPERATIONAL_BRIDGE_TOKEN`.
+
+    See [Workers and jobs](../../operate/run/workers-and-jobs.md#start-a-go-worker-group).
+
 Generate current entries for:
 
 - Celery broker, result backend, queue lists, concurrency, and shutdown grace;
@@ -112,7 +139,7 @@ runs and 10,000,000–500,000,000 microUSD.
 
 For every generated entry, include:
 
-- key and supported aliases;
+- key and supported aliases, including the canonical CLI flag for Go worker settings;
 - type and validation;
 - required, optional, or conditional state;
 - default, if the runtime defines one;

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -44,8 +44,14 @@ const (
 	// scripts/worker/provision_river_roles.sql (deployed environments).
 	defaultCoordinatorDatabaseRole = "devhealth_coordinator"
 	defaultStreamReplicas          = 1
-	localStatusMappingPath         = "/app/config/status_mapping.yaml"
-	localInvestmentAreasPath       = "/app/config/investment_areas.yaml"
+	// The OpenTelemetry defaults mirror src/dev_health_ops/tracing.py exactly,
+	// so a sync run crossing the Python/Go boundary is sampled consistently.
+	defaultOTelServiceName   = "dev-health-ops"
+	defaultOTelEnvironment   = "production"
+	defaultOTelEndpoint      = "localhost:4317"
+	defaultOTelSampleRate    = 0.1
+	localStatusMappingPath   = "/app/config/status_mapping.yaml"
+	localInvestmentAreasPath = "/app/config/investment_areas.yaml"
 )
 
 const (
@@ -70,16 +76,24 @@ type Spec struct {
 	Service string
 	// Profile is already resolved and validated by the caller; config does not
 	// own profile selection (CHAOS-3875).
-	Profile          string
-	RequireQueues    bool
-	Queues           []string
-	QueueConcurrency []string
-	WorkerGroup      string
-	ShutdownTimeout  string
-	// UnreclaimableSweep is the raw --unreclaimable-sweep value. Empty means
-	// the flag was not given, in which case the environment is consulted.
-	UnreclaimableSweep string
-	LookupEnv          secrets.LookupEnv
+	Profile       string
+	RequireQueues bool
+	// Queues is flag-only on purpose (CHAOS-3875): every deploy artifact passes
+	// --queues, so a parallel environment path would only be a second way to
+	// say the same thing.
+	Queues []string
+	// Overrides carries the values the operator supplied as flags, keyed by the
+	// environment variable each flag shadows. Resolution is flag > env >
+	// default: an override is consulted first and the environment is the
+	// 12-factor fallback beneath it.
+	//
+	// This is precedence, not a conflict: CHAOS-4020 moves deployed
+	// configuration into `command:` while host .env files still carry the old
+	// variables, and a configuration that hard-failed whenever both surfaces
+	// named the same setting could not be rolled out one surface at a time.
+	// The shadowed environment value is reported at startup instead.
+	Overrides map[string]string
+	LookupEnv secrets.LookupEnv
 }
 
 // Config contains typed runtime settings. Sensitive values use secrets.Value,
@@ -98,6 +112,11 @@ type Config struct {
 	// WorkerGroup is an observability identity only. It never selects queues or
 	// changes handler construction.
 	WorkerGroup string
+	// EnvOnlySettings names the settings that were resolved from the
+	// environment even though a canonical flag exists for them. The shell warns
+	// about each at startup so a deployment still configured the old way is
+	// visible rather than merely working.
+	EnvOnlySettings []string
 
 	HTTPAddress string
 	// UnreclaimableSweepMode is the resolved off|shadow|active choice for the
@@ -258,24 +277,30 @@ const (
 // dependencies. A command argument and its environment fallback may not both
 // be set.
 func Load(spec Spec) (Config, error) {
-	lookup := spec.LookupEnv
-	if lookup == nil {
-		lookup = os.LookupEnv
+	environment := spec.LookupEnv
+	if environment == nil {
+		environment = os.LookupEnv
 	}
+	if err := validateOverrides(spec.Overrides); err != nil {
+		return Config{}, err
+	}
+	lookup := layeredLookup(spec.Overrides, environment)
 
 	cfg := Config{Service: spec.Service}
+	cfg.EnvOnlySettings = envOnlySettings(spec, environment)
 	if err := validateName("service", cfg.Service); err != nil {
 		return Config{}, err
 	}
 
 	cfg.HTTPAddress = envOrDefault(lookup, "DEV_HEALTH_HTTP_ADDR", defaultHTTPAddress)
 	if _, _, err := net.SplitHostPort(cfg.HTTPAddress); err != nil {
-		return Config{}, fmt.Errorf("DEV_HEALTH_HTTP_ADDR must be a host:port address")
+		return Config{}, fmt.Errorf(
+			"%s must be a host:port address", settingLabel("DEV_HEALTH_HTTP_ADDR"),
+		)
 	}
 
 	var err error
-	cfg.ShutdownTimeout, err = durationArgumentOrEnv(
-		spec.ShutdownTimeout,
+	cfg.ShutdownTimeout, err = durationEnv(
 		lookup,
 		"DEV_HEALTH_SHUTDOWN_TIMEOUT",
 		defaultShutdownTimeout,
@@ -285,17 +310,15 @@ func Load(spec Spec) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	cfg.ShutdownTimeoutExplicit = durationArgumentOrEnvSet(
-		spec.ShutdownTimeout, lookup, "DEV_HEALTH_SHUTDOWN_TIMEOUT",
+	cfg.ShutdownTimeoutExplicit = settingConfigured(lookup, "DEV_HEALTH_SHUTDOWN_TIMEOUT")
+	// CHAOS-4005's sweep resolves through the same layered lookup as every
+	// other setting: --unreclaimable-sweep is an override keyed by
+	// SYNC_UNRECLAIMABLE_SWEEP, so flag > env > default falls out of the shared
+	// mechanism rather than a private branch. Empty means neither surface
+	// supplied a value and ParseSweepMode applies the shadow default.
+	cfg.UnreclaimableSweepMode = strings.TrimSpace(
+		envOrDefault(lookup, "SYNC_UNRECLAIMABLE_SWEEP", ""),
 	)
-	// Flag is canonical; the environment is only consulted when the flag was
-	// not given (CHAOS-4020).
-	cfg.UnreclaimableSweepMode = strings.TrimSpace(spec.UnreclaimableSweep)
-	if cfg.UnreclaimableSweepMode == "" {
-		if value, ok := lookup("SYNC_UNRECLAIMABLE_SWEEP"); ok {
-			cfg.UnreclaimableSweepMode = strings.TrimSpace(value)
-		}
-	}
 	cfg.OperationalBridgeAllowInsecure, err = boolEnv(
 		lookup, "WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE", false,
 	)
@@ -307,185 +330,11 @@ func Load(spec Spec) (Config, error) {
 		return Config{}, err
 	}
 	cfg.LocalAllProviderRoutes = allProviderRoutes
-	for _, item := range []struct {
-		name   string
-		target *bool
-	}{
-		{
-			name:   "WORKER_LINEAR_WORK_ITEMS_ENABLED",
-			target: &cfg.WorkerLinearWorkItemsEnabled,
-		},
-		{
-			name:   "WORKER_JIRA_WORK_ITEMS_ENABLED",
-			target: &cfg.WorkerJiraWorkItemsEnabled,
-		},
-		{
-			name:   "WORKER_JIRA_INCIDENTS_ENABLED",
-			target: &cfg.WorkerJiraIncidentsEnabled,
-		},
-		{
-			name:   "WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED",
-			target: &cfg.WorkerLaunchDarklyFeatureFlagsEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_REPO_METADATA_ENABLED",
-			target: &cfg.WorkerGithubRepoMetadataEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_REPO_METADATA_ENABLED",
-			target: &cfg.WorkerGitlabRepoMetadataEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_COMMITS_ENABLED",
-			target: &cfg.WorkerGitlabCommitsEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_COMMIT_STATS_ENABLED",
-			target: &cfg.WorkerGitlabCommitStatsEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_CICD_ENABLED",
-			target: &cfg.WorkerGitlabCICDEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_TESTS_ENABLED",
-			target: &cfg.WorkerGitlabTestsEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_INCIDENTS_ENABLED",
-			target: &cfg.WorkerGitlabIncidentsEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_DEPLOYMENTS_ENABLED",
-			target: &cfg.WorkerGitlabDeploymentsEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_FEATURE_FLAGS_ENABLED",
-			target: &cfg.WorkerGitlabFeatureFlagsEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_FILES_ENABLED",
-			target: &cfg.WorkerGitlabFilesEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_BLAME_ENABLED",
-			target: &cfg.WorkerGitlabBlameEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_PRS_ENABLED",
-			target: &cfg.WorkerGitlabPRsEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_PR_REVIEWS_ENABLED",
-			target: &cfg.WorkerGitlabPRReviewsEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_PR_COMMENTS_ENABLED",
-			target: &cfg.WorkerGitlabPRCommentsEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_SECURITY_ENABLED",
-			target: &cfg.WorkerGitlabSecurityEnabled,
-		},
-		{
-			name:   "WORKER_GITLAB_WORK_ITEMS_ENABLED",
-			target: &cfg.WorkerGitlabWorkItemsEnabled,
-		},
-		{
-			name:   "WORKER_PAGERDUTY_SERVICES_ENABLED",
-			target: &cfg.WorkerPagerDutyServicesEnabled,
-		},
-		{
-			name:   "WORKER_PAGERDUTY_BUSINESS_SERVICES_ENABLED",
-			target: &cfg.WorkerPagerDutyBusinessServicesEnabled,
-		},
-		{
-			name:   "WORKER_PAGERDUTY_ESCALATION_POLICIES_ENABLED",
-			target: &cfg.WorkerPagerDutyEscalationPoliciesEnabled,
-		},
-		{
-			name:   "WORKER_PAGERDUTY_SCHEDULES_ENABLED",
-			target: &cfg.WorkerPagerDutySchedulesEnabled,
-		},
-		{
-			name:   "WORKER_PAGERDUTY_ON_CALLS_ENABLED",
-			target: &cfg.WorkerPagerDutyOnCallsEnabled,
-		},
-		{
-			name:   "WORKER_PAGERDUTY_USERS_ENABLED",
-			target: &cfg.WorkerPagerDutyUsersEnabled,
-		},
-		{
-			name:   "WORKER_PAGERDUTY_TEAMS_ENABLED",
-			target: &cfg.WorkerPagerDutyTeamsEnabled,
-		},
-		{
-			name:   "WORKER_PAGERDUTY_INCIDENTS_ENABLED",
-			target: &cfg.WorkerPagerDutyIncidentsEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_PRS_ENABLED",
-			target: &cfg.WorkerGithubPRsEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_PR_REVIEWS_ENABLED",
-			target: &cfg.WorkerGithubPRReviewsEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_PR_COMMENTS_ENABLED",
-			target: &cfg.WorkerGithubPRCommentsEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_CICD_ENABLED",
-			target: &cfg.WorkerGithubCICDEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_COMMITS_ENABLED",
-			target: &cfg.WorkerGithubCommitsEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_DEPLOYMENTS_ENABLED",
-			target: &cfg.WorkerGithubDeploymentsEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_SECURITY_ENABLED",
-			target: &cfg.WorkerGithubSecurityEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_FILES_ENABLED",
-			target: &cfg.WorkerGithubFilesEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_COMMIT_STATS_ENABLED",
-			target: &cfg.WorkerGithubCommitStatsEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_BLAME_ENABLED",
-			target: &cfg.WorkerGithubBlameEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_TESTS_ENABLED",
-			target: &cfg.WorkerGithubTestsEnabled,
-		},
-		{
-			name:   "WORKER_GITHUB_WORK_ITEMS_ENABLED",
-			target: &cfg.WorkerGithubWorkItemsEnabled,
-		},
-	} {
-		fallback := false
-		if allProviderRoutes {
-			fallback, err = providerRoutePresetDefault(lookup, item.name)
-			if err != nil {
-				return Config{}, err
-			}
-		}
-		*item.target, err = boolEnv(lookup, item.name, fallback)
-		if err != nil {
-			return Config{}, err
-		}
+	if err := applyRoutes(&cfg, lookup, allProviderRoutes); err != nil {
+		return Config{}, err
 	}
 	if cfg.WorkerGithubCICDEnabled && cfg.WorkerGithubTestsEnabled {
-		return Config{}, fmt.Errorf("WORKER_GITHUB_CICD_ENABLED and WORKER_GITHUB_TESTS_ENABLED are mutually exclusive: both delegate to one complete TestOps writer")
+		return Config{}, fmt.Errorf("github/cicd and github/tests are mutually exclusive: both delegate to one complete TestOps writer (WORKER_GITHUB_CICD_ENABLED, WORKER_GITHUB_TESTS_ENABLED)")
 	}
 	githubPRSocialAliases := 0
 	for _, enabled := range []bool{
@@ -498,10 +347,10 @@ func Load(spec Spec) (Config, error) {
 		}
 	}
 	if githubPRSocialAliases > 1 {
-		return Config{}, fmt.Errorf("WORKER_GITHUB_PRS_ENABLED, WORKER_GITHUB_PR_REVIEWS_ENABLED, and WORKER_GITHUB_PR_COMMENTS_ENABLED are mutually exclusive: all delegate to one complete PR-social writer")
+		return Config{}, fmt.Errorf("github/prs, github/pr-reviews, and github/pr-comments are mutually exclusive: all delegate to one complete PR-social writer")
 	}
 	if cfg.WorkerGitlabCICDEnabled && cfg.WorkerGitlabTestsEnabled {
-		return Config{}, fmt.Errorf("WORKER_GITLAB_CICD_ENABLED and WORKER_GITLAB_TESTS_ENABLED are mutually exclusive: both delegate to one complete TestOps writer")
+		return Config{}, fmt.Errorf("gitlab/cicd and gitlab/tests are mutually exclusive: both delegate to one complete TestOps writer (WORKER_GITLAB_CICD_ENABLED, WORKER_GITLAB_TESTS_ENABLED)")
 	}
 	gitlabPRSocialAliases := 0
 	for _, enabled := range []bool{
@@ -514,7 +363,7 @@ func Load(spec Spec) (Config, error) {
 		}
 	}
 	if gitlabPRSocialAliases > 1 {
-		return Config{}, fmt.Errorf("WORKER_GITLAB_PRS_ENABLED, WORKER_GITLAB_PR_REVIEWS_ENABLED, and WORKER_GITLAB_PR_COMMENTS_ENABLED are mutually exclusive: all delegate to one complete PR-social writer")
+		return Config{}, fmt.Errorf("gitlab/prs, gitlab/pr-reviews, and gitlab/pr-comments are mutually exclusive: all delegate to one complete PR-social writer")
 	}
 	cfg.WorkerGithubWorkItemsStatusMappingPath = envOrDefault(
 		lookup,
@@ -769,8 +618,7 @@ func localAllProviderRoutes(lookup secrets.LookupEnv) (bool, error) {
 	if preset != "all" {
 		return false, fmt.Errorf("%s must be empty or all", providerRoutesPresetEnv)
 	}
-	environment, _ := lookup(devHealthEnv)
-	if strings.ToLower(strings.TrimSpace(environment)) != "local" {
+	if !environmentIsLocal(lookup) {
 		return false, fmt.Errorf("%s=all requires %s=local", providerRoutesPresetEnv, devHealthEnv)
 	}
 	return true, nil
@@ -1007,41 +855,6 @@ func durationEnv(
 	return value, nil
 }
 
-// durationArgumentOrEnvSet reports whether a duration was supplied by flag or
-// environment, as opposed to falling back to the package default.
-func durationArgumentOrEnvSet(argument string, lookup secrets.LookupEnv, key string) bool {
-	if strings.TrimSpace(argument) != "" {
-		return true
-	}
-	value, set := lookup(key)
-	return set && strings.TrimSpace(value) != ""
-}
-
-func durationArgumentOrEnv(
-	argument string,
-	lookup secrets.LookupEnv,
-	key string,
-	fallback, minimum, maximum time.Duration,
-) (time.Duration, error) {
-	argument = strings.TrimSpace(argument)
-	environment, environmentSet := lookup(key)
-	environment = strings.TrimSpace(environment)
-	if argument != "" && environmentSet && environment != "" {
-		return 0, fmt.Errorf("--shutdown-timeout conflicts with %s", key)
-	}
-	if argument == "" {
-		return durationEnv(lookup, key, fallback, minimum, maximum)
-	}
-	value, err := time.ParseDuration(argument)
-	if err != nil {
-		return 0, errors.New("--shutdown-timeout must be a duration")
-	}
-	if value < minimum || value > maximum {
-		return 0, fmt.Errorf("--shutdown-timeout must be between %s and %s", minimum, maximum)
-	}
-	return value, nil
-}
-
 func logLevelEnv(lookup secrets.LookupEnv) (slog.Level, error) {
 	value := strings.ToLower(envOrDefault(lookup, "DEV_HEALTH_LOG_LEVEL", "info"))
 	switch value {
@@ -1054,7 +867,9 @@ func logLevelEnv(lookup secrets.LookupEnv) (slog.Level, error) {
 	case "error":
 		return slog.LevelError, nil
 	default:
-		return 0, fmt.Errorf("DEV_HEALTH_LOG_LEVEL must be debug, info, warn, or error")
+		return 0, fmt.Errorf(
+			"%s must be debug, info, warn, or error", settingLabel("DEV_HEALTH_LOG_LEVEL"),
+		)
 	}
 }
 
@@ -1099,64 +914,42 @@ func queueSelection(spec Spec, lookup secrets.LookupEnv) ([]string, error) {
 }
 
 func workerQueueRuntime(spec Spec, lookup secrets.LookupEnv, queues []string) (string, map[string]int, error) {
-	group, groupSet := lookup("DEV_HEALTH_WORKER_GROUP")
-	encoded, concurrencySet := lookup("DEV_HEALTH_QUEUE_CONCURRENCY")
-	group = strings.TrimSpace(group)
-	encoded = strings.TrimSpace(encoded)
-	argumentGroup := strings.TrimSpace(spec.WorkerGroup)
-	argumentConcurrency := append([]string(nil), spec.QueueConcurrency...)
+	group := strings.TrimSpace(envOrDefault(lookup, "DEV_HEALTH_WORKER_GROUP", ""))
+	encoded := strings.TrimSpace(envOrDefault(lookup, "DEV_HEALTH_QUEUE_CONCURRENCY", ""))
 	if !spec.RequireQueues {
-		if argumentGroup != "" || len(argumentConcurrency) > 0 ||
-			(groupSet && group != "") || (concurrencySet && encoded != "") {
+		if group != "" || encoded != "" {
 			return "", nil, fmt.Errorf("%s does not accept worker queue runtime settings", spec.Service)
 		}
 		return "", nil, nil
 	}
-	if argumentGroup != "" && groupSet && group != "" {
-		return "", nil, errors.New("--worker-group conflicts with DEV_HEALTH_WORKER_GROUP")
-	}
-	if len(argumentConcurrency) > 0 && concurrencySet && encoded != "" {
-		return "", nil, errors.New("--queue-concurrency conflicts with DEV_HEALTH_QUEUE_CONCURRENCY")
-	}
-	if argumentGroup != "" {
-		group = argumentGroup
-	}
-	groupSetting := "DEV_HEALTH_WORKER_GROUP"
-	if argumentGroup != "" {
-		groupSetting = "--worker-group"
-	}
 	if group == "" {
 		group = "worker"
 	}
+	groupSetting := settingLabel("DEV_HEALTH_WORKER_GROUP")
 	if len(group) > 64 {
 		return "", nil, fmt.Errorf("%s exceeds 64 characters", groupSetting)
 	}
 	if err := validateName(groupSetting, group); err != nil {
 		return "", nil, err
 	}
-	if len(argumentConcurrency) == 0 && encoded != "" {
-		argumentConcurrency = []string{encoded}
-	}
-	if len(argumentConcurrency) == 0 {
-		return "", nil, errors.New("queue concurrency is required")
+	if encoded == "" {
+		return "", nil, fmt.Errorf("%s is required", settingLabel("DEV_HEALTH_QUEUE_CONCURRENCY"))
 	}
 	concurrency := make(map[string]int)
-	for _, raw := range argumentConcurrency {
-		for _, item := range strings.Split(raw, ",") {
-			parts := strings.Split(item, "=")
-			if len(parts) != 2 {
-				return "", nil, errors.New("queue concurrency must use queue=workers entries")
-			}
-			queue := strings.TrimSpace(parts[0])
-			workers, parseErr := strconv.Atoi(strings.TrimSpace(parts[1]))
-			if !validQueueName(queue) || parseErr != nil || workers < 1 || workers > 10_000 {
-				return "", nil, errors.New("queue concurrency has an invalid entry")
-			}
-			if _, duplicate := concurrency[queue]; duplicate {
-				return "", nil, fmt.Errorf("queue concurrency for %q is defined more than once", queue)
-			}
-			concurrency[queue] = workers
+	for _, item := range strings.Split(encoded, ",") {
+		parts := strings.Split(item, "=")
+		if len(parts) != 2 {
+			return "", nil, errors.New("queue concurrency must use queue=workers entries")
 		}
+		queue := strings.TrimSpace(parts[0])
+		workers, parseErr := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if !validQueueName(queue) || parseErr != nil || workers < 1 || workers > 10_000 {
+			return "", nil, errors.New("queue concurrency has an invalid entry")
+		}
+		if _, duplicate := concurrency[queue]; duplicate {
+			return "", nil, fmt.Errorf("queue concurrency for %q is defined more than once", queue)
+		}
+		concurrency[queue] = workers
 	}
 	if len(concurrency) != len(queues) {
 		return "", nil, errors.New("queue concurrency must cover the selected queues exactly")

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -197,44 +197,97 @@ func TestWorkerQueueSelectionRejectsInvalidOrAmbiguousInput(t *testing.T) {
 	}
 }
 
-func TestWorkerProcessArgumentsRejectEnvironmentConflicts(t *testing.T) {
+// TestFlagOverridesTakePrecedenceOverEnvironment pins the resolution order
+// CHAOS-4020 introduced. These three settings previously made a Load that named
+// both surfaces a hard error. That could not survive the migration this ticket
+// performs: deployed configuration moves into `command:` while host .env files
+// still carry the same variables, so a conflict rule would have failed every
+// worker at the moment the flags were added. The environment is a fallback
+// beneath the flag, and the shadowed setting is reported rather than fatal.
+func TestFlagOverridesTakePrecedenceOverEnvironment(t *testing.T) {
 	t.Parallel()
 
-	for name, spec := range map[string]Spec{
-		"queue concurrency": {
-			Service:          "dev-health-worker",
-			RequireQueues:    true,
-			Queues:           []string{"heartbeat"},
-			QueueConcurrency: []string{"heartbeat=1"},
-			LookupEnv: lookup(map[string]string{
-				"DEV_HEALTH_QUEUE_CONCURRENCY": "heartbeat=2",
-			}),
+	cfg, err := Load(Spec{
+		Service:       "dev-health-worker",
+		RequireQueues: true,
+		Queues:        []string{"heartbeat"},
+		Overrides: map[string]string{
+			"DEV_HEALTH_QUEUE_CONCURRENCY": "heartbeat=1",
+			"DEV_HEALTH_WORKER_GROUP":      "command-group",
+			"DEV_HEALTH_SHUTDOWN_TIMEOUT":  "30s",
 		},
-		"worker group": {
-			Service:          "dev-health-worker",
-			RequireQueues:    true,
-			Queues:           []string{"heartbeat"},
-			QueueConcurrency: []string{"heartbeat=1"},
-			WorkerGroup:      "command-group",
-			LookupEnv: lookup(map[string]string{
-				"DEV_HEALTH_WORKER_GROUP": "environment-group",
-			}),
-		},
-		"shutdown timeout": {
-			Service:          "dev-health-worker",
-			RequireQueues:    true,
-			Queues:           []string{"heartbeat"},
-			QueueConcurrency: []string{"heartbeat=1"},
-			ShutdownTimeout:  "30s",
-			LookupEnv: lookup(map[string]string{
-				"DEV_HEALTH_SHUTDOWN_TIMEOUT": "60s",
-			}),
-		},
+		LookupEnv: lookup(map[string]string{
+			"DEV_HEALTH_QUEUE_CONCURRENCY": "heartbeat=2",
+			"DEV_HEALTH_WORKER_GROUP":      "environment-group",
+			"DEV_HEALTH_SHUTDOWN_TIMEOUT":  "60s",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.WorkerGroup != "command-group" {
+		t.Fatalf("worker group = %q, want the flag value", cfg.WorkerGroup)
+	}
+	if cfg.WorkerQueueConcurrency["heartbeat"] != 1 {
+		t.Fatalf("heartbeat concurrency = %d, want the flag value 1", cfg.WorkerQueueConcurrency["heartbeat"])
+	}
+	if cfg.ShutdownTimeout != 30*time.Second {
+		t.Fatalf("shutdown timeout = %s, want the flag value 30s", cfg.ShutdownTimeout)
+	}
+	// Every setting came from a flag, so none is reported as environment-only.
+	if len(cfg.EnvOnlySettings) != 0 {
+		t.Fatalf("EnvOnlySettings = %v, want empty when every setting was a flag", cfg.EnvOnlySettings)
+	}
+}
+
+// TestEnvironmentFallbackIsReportedNotSilent proves the other half: a setting
+// that has a flag but was supplied through the environment still works and is
+// named, so a deployment configured the old way is visible at startup instead
+// of merely functioning.
+func TestEnvironmentFallbackIsReportedNotSilent(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(Spec{
+		Service:       "dev-health-worker",
+		RequireQueues: true,
+		Queues:        []string{"heartbeat"},
+		Overrides:     map[string]string{"DEV_HEALTH_QUEUE_CONCURRENCY": "heartbeat=1"},
+		LookupEnv: lookup(map[string]string{
+			"DEV_HEALTH_WORKER_GROUP": "environment-group",
+			"DEV_HEALTH_LOG_LEVEL":    "debug",
+			// A provider route switch is environment-only by design and has no
+			// flag, so it is never reported as an env-only *setting*.
+			"WORKER_LINEAR_WORK_ITEMS_ENABLED": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.WorkerGroup != "environment-group" {
+		t.Fatalf("worker group = %q, want the environment fallback", cfg.WorkerGroup)
+	}
+	want := []string{"log-level", "worker-group"}
+	if !slices.Equal(cfg.EnvOnlySettings, want) {
+		t.Fatalf("EnvOnlySettings = %v, want %v", cfg.EnvOnlySettings, want)
+	}
+}
+
+// TestOverridesRejectCredentials pins the rule that keeps DSNs and tokens off
+// the command line, where `ps`, `docker inspect`, and `docker compose config`
+// would all expose them.
+func TestOverridesRejectCredentials(t *testing.T) {
+	t.Parallel()
+
+	for name, override := range map[string]map[string]string{
+		"credential": {"POSTGRES_URI": "postgres://user:pw@host/db"},
+		"undeclared": {"NOT_A_SETTING": "value"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			spec := workerSpec(nil)
+			spec.Overrides = override
 			if _, err := Load(spec); err == nil {
-				t.Fatal("expected command argument and environment conflict to fail")
+				t.Fatal("expected the override to be rejected")
 			}
 		})
 	}
@@ -772,11 +825,18 @@ func TestUnreclaimableSweepFlagBeatsEnvironment(t *testing.T) {
 		{"neither", "", nil, ""},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			cfg, err := Load(Spec{
-				Service:            "dev-health-reconciler",
-				UnreclaimableSweep: testCase.flag,
-				LookupEnv:          lookup(testCase.env),
-			})
+			spec := Spec{
+				Service:   "dev-health-reconciler",
+				LookupEnv: lookup(testCase.env),
+			}
+			// The flag reaches Load as an override keyed by the variable it
+			// shadows, exactly as the shell layer supplies it.
+			if testCase.flag != "" {
+				spec.Overrides = map[string]string{
+					"SYNC_UNRECLAIMABLE_SWEEP": testCase.flag,
+				}
+			}
+			cfg, err := Load(spec)
 			if err != nil {
 				t.Fatalf("load config: %v", err)
 			}
@@ -785,5 +845,143 @@ func TestUnreclaimableSweepFlagBeatsEnvironment(t *testing.T) {
 					cfg.UnreclaimableSweepMode, testCase.want)
 			}
 		})
+	}
+}
+
+// TestBlankValuesAreTreatedAsUnsetOnBothSurfaces pins the edge the removed
+// conflict branches used to arbitrate.
+//
+// ShutdownTimeoutExplicit feeds cmd/dev-health-worker's drain-budget decision:
+// when it is false and the grace is at the package default, the worker derives
+// its budget from the queue selection instead of trusting 30s. A blank value
+// that read as "explicitly set" would silently hand a real worker a 30s drain
+// budget that no real queue selection can satisfy, so blank must mean unset on
+// BOTH surfaces, exactly as it did before.
+func TestBlankValuesAreTreatedAsUnsetOnBothSurfaces(t *testing.T) {
+	t.Parallel()
+
+	for name, spec := range map[string]Spec{
+		"blank environment": {
+			Service:       "dev-health-worker",
+			RequireQueues: true,
+			Queues:        []string{"heartbeat"},
+			Overrides:     map[string]string{"DEV_HEALTH_QUEUE_CONCURRENCY": "heartbeat=1"},
+			LookupEnv: lookup(map[string]string{
+				"DEV_HEALTH_SHUTDOWN_TIMEOUT": "   ",
+			}),
+		},
+		"blank flag": {
+			Service:       "dev-health-worker",
+			RequireQueues: true,
+			Queues:        []string{"heartbeat"},
+			Overrides: map[string]string{
+				"DEV_HEALTH_QUEUE_CONCURRENCY": "heartbeat=1",
+				"DEV_HEALTH_SHUTDOWN_TIMEOUT":  "",
+			},
+			LookupEnv: lookup(nil),
+		},
+		"absent entirely": {
+			Service:       "dev-health-worker",
+			RequireQueues: true,
+			Queues:        []string{"heartbeat"},
+			Overrides:     map[string]string{"DEV_HEALTH_QUEUE_CONCURRENCY": "heartbeat=1"},
+			LookupEnv:     lookup(nil),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cfg, err := Load(spec)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if cfg.ShutdownTimeoutExplicit {
+				t.Error("a blank or absent value must not read as an operator choice")
+			}
+			if cfg.ShutdownTimeout != DefaultShutdownTimeout {
+				t.Fatalf("shutdown timeout = %s, want the package default", cfg.ShutdownTimeout)
+			}
+		})
+	}
+}
+
+// TestBlankWorkerGroupFallsBackToTheDefaultName keeps the other blank-value
+// path honest: an empty group on either surface is the default identity, not a
+// validation failure and not an empty label.
+func TestBlankWorkerGroupFallsBackToTheDefaultName(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(Spec{
+		Service:       "dev-health-worker",
+		RequireQueues: true,
+		Queues:        []string{"heartbeat"},
+		Overrides: map[string]string{
+			"DEV_HEALTH_QUEUE_CONCURRENCY": "heartbeat=1",
+			"DEV_HEALTH_WORKER_GROUP":      "   ",
+		},
+		LookupEnv: lookup(map[string]string{"DEV_HEALTH_WORKER_GROUP": "  "}),
+	})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.WorkerGroup != "worker" {
+		t.Fatalf("worker group = %q, want the default identity", cfg.WorkerGroup)
+	}
+}
+
+// TestNonQueueServicesStillRejectQueueRuntimeSettings keeps the guard the
+// layered lookup could have quietly weakened: a reconciler or scheduler that
+// inherits a worker's environment must still refuse queue runtime settings
+// rather than silently ignoring them.
+func TestNonQueueServicesStillRejectQueueRuntimeSettings(t *testing.T) {
+	t.Parallel()
+
+	for name, values := range map[string]map[string]string{
+		"worker group":      {"DEV_HEALTH_WORKER_GROUP": "inherited"},
+		"queue concurrency": {"DEV_HEALTH_QUEUE_CONCURRENCY": "sync=2"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := Load(workerSpec(values)); err == nil {
+				t.Fatal("a non-queue service must reject queue runtime settings")
+			}
+		})
+	}
+}
+
+// TestQueueSelectionAcceptsDottedSubpathNames is a forward-compatibility guard
+// for CHAOS-4027.
+//
+// That ticket introduces finer-grained River queues following a dotted
+// convention, so an operator can shard by hand: -Q sync.github for a provider,
+// -Q sync.github.heavy for one cost class. The CLI needs no change to support
+// it, because -Q takes an arbitrary queue list and validation is a charset
+// check plus the runtime's selected-equals-constructed rule -- NOT a
+// restriction on queue-name shape.
+//
+// This test exists so that stays true. Tightening queue validation into a
+// pattern that assumes flat names would break CHAOS-4027 silently, at the
+// moment those queues first appear rather than in the change that caused it.
+func TestQueueSelectionAcceptsDottedSubpathNames(t *testing.T) {
+	t.Parallel()
+
+	queues := []string{"sync.github", "sync.github.heavy", "sync_provider"}
+	cfg, err := Load(Spec{
+		Service:       "dev-health-worker",
+		RequireQueues: true,
+		Queues:        []string{strings.Join(queues, ",")},
+		Overrides: map[string]string{
+			"DEV_HEALTH_QUEUE_CONCURRENCY": "sync.github=1,sync.github.heavy=2,sync_provider=1",
+		},
+		LookupEnv: lookup(nil),
+	})
+	if err != nil {
+		t.Fatalf("dotted subpath queue names must be accepted: %v", err)
+	}
+	want := []string{"sync.github", "sync.github.heavy", "sync_provider"}
+	if !slices.Equal(cfg.Queues, want) {
+		t.Fatalf("queues = %v, want %v", cfg.Queues, want)
+	}
+	if cfg.WorkerQueueConcurrency["sync.github.heavy"] != 2 {
+		t.Fatalf("per-queue concurrency must key on the dotted name: %v", cfg.WorkerQueueConcurrency)
 	}
 }

--- a/internal/platform/config/options.go
+++ b/internal/platform/config/options.go
@@ -1,0 +1,472 @@
+package config
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Kind is the parse type of an option value. It tells the flag layer which
+// flag.FlagSet registration to make and tells --help what to print after the
+// flag name.
+type Kind uint8
+
+const (
+	// KindString is an opaque string value.
+	KindString Kind = iota
+	// KindBool is a true/false value. Bool options are registered so that both
+	// --flag and --flag=false work.
+	KindBool
+	// KindDuration is a Go duration ("30s", "16m").
+	KindDuration
+	// KindInt is a bounded integer.
+	KindInt
+)
+
+// Placeholder is the value name --help prints after the flag.
+func (k Kind) Placeholder() string {
+	switch k {
+	case KindBool:
+		return "true|false"
+	case KindDuration:
+		return "duration"
+	case KindInt:
+		return "n"
+	default:
+		return "value"
+	}
+}
+
+// Option declares one operator-settable setting.
+//
+// This registry is the single discovery surface CHAOS-4020 asks for: --help is
+// rendered from it, the flag layer is registered from it, and Load resolves
+// through it. A setting that is not declared here has no flag, so adding one
+// cannot be forgotten halfway -- the previous four-surface wiring problem
+// (CHAOS-3942) was exactly a setting that existed in some surfaces but not
+// others.
+type Option struct {
+	// Flag is the canonical long flag, without leading dashes. Empty for a
+	// secret, which is deliberately environment-only.
+	Flag string
+	// Short is an optional single-character alias registered alongside Flag.
+	Short string
+	// Aliases are additional accepted spellings of this option, kept so a
+	// rename does not break manifests that are not in this repository. They are
+	// noted in --help rather than listed as options of their own.
+	Aliases []string
+	// Env is the 12-factor fallback consulted when the flag is absent. Empty
+	// means the setting is flag-only.
+	Env  string
+	Kind Kind
+	// Default is the documented default, printed by --help. It is descriptive:
+	// the authoritative default lives at the resolution site in Load.
+	Default string
+	Usage   string
+	// Secret marks a value that must never reach a command line. Process
+	// arguments are readable by anyone who can run `ps` or `docker inspect`,
+	// and `docker compose config` renders them verbatim, so DSNs and tokens
+	// stay in the environment on purpose and --help says so.
+	Secret bool
+	// QueueOnly restricts the option to binaries that consume queues. Load
+	// already rejects queue settings on the other services; registering the
+	// flag only where it applies keeps their --help honest.
+	QueueOnly bool
+	// Services, when non-empty, restricts the option to the named services.
+	// This is the extension point for a single-binary knob: declare it here
+	// with Services set and the flag, --help entry, env fallback, and
+	// precedence all follow without touching the flag layer.
+	Services []string
+	// Group is the --help section heading.
+	Group string
+}
+
+// Help section headings, in display order.
+const (
+	GroupWorker      = "Worker"
+	GroupRuntime     = "Process runtime"
+	GroupDatabase    = "Database and River"
+	GroupRoutes      = "Provider routes"
+	GroupBridge      = "Operational bridge"
+	GroupCredentials = "Credentials"
+)
+
+var groupOrder = []string{
+	GroupWorker,
+	GroupRuntime,
+	GroupDatabase,
+	GroupRoutes,
+	GroupBridge,
+	GroupCredentials,
+}
+
+// optionRegistry declares every operator-settable setting of the Go worker
+// binaries. The 40 provider route switches are deliberately absent: they have
+// no flag at all. A worker executes the queues it subscribes to, and those
+// switches survive only as the Python producer / Go executor agreement
+// (see routes.go).
+var optionRegistry = []Option{
+	// Worker: queue topology and identity.
+	{
+		// Celery spells this -Q; -q is kept because the Go worker has always
+		// accepted it and every checked-in manifest uses --queues.
+		Flag: "queues", Short: "Q", Aliases: []string{"q"}, Kind: KindString,
+		QueueOnly: true, Group: GroupWorker,
+		Usage: "queues to consume (comma-separated or repeatable), mirroring celery worker -Q",
+	},
+	{
+		Flag: "concurrency", Short: "c", Aliases: []string{"queue-concurrency"},
+		Env:  "DEV_HEALTH_QUEUE_CONCURRENCY",
+		Kind: KindString, QueueOnly: true, Group: GroupWorker,
+		Usage: "queue worker budgets as queue=workers entries (comma-separated or repeatable)",
+	},
+	{
+		Flag: "worker-group", Env: "DEV_HEALTH_WORKER_GROUP", Kind: KindString,
+		Default: "worker", QueueOnly: true, Group: GroupWorker,
+		Usage: "stable worker group label for logs and metrics; never selects queues",
+	},
+
+	// Process runtime.
+	{
+		Flag: "profile", Env: "DEV_HEALTH_PROFILE", Kind: KindString,
+		Services: []string{"dev-health-stream-runner"}, Group: GroupRuntime,
+		Usage: "runtime profile",
+	},
+	{
+		Flag: "http-addr", Env: "DEV_HEALTH_HTTP_ADDR", Kind: KindString,
+		Default: defaultHTTPAddress, Group: GroupRuntime,
+		Usage: "host:port for the operator HTTP server (/healthz, /readyz, /metrics)",
+	},
+	{
+		Flag: "shutdown-timeout", Env: "DEV_HEALTH_SHUTDOWN_TIMEOUT", Kind: KindDuration,
+		Default: defaultShutdownTimeout.String(), Group: GroupRuntime,
+		Usage: "graceful shutdown budget; must cover the longest selected job timeout",
+	},
+	{
+		Flag: "health-check-timeout", Env: "DEV_HEALTH_HEALTH_CHECK_TIMEOUT", Kind: KindDuration,
+		Default: defaultHealthCheckTimout.String(), Group: GroupRuntime,
+		Usage: "per-dependency readiness probe timeout",
+	},
+	{
+		// celery worker spells this --loglevel; both are accepted.
+		Flag: "log-level", Aliases: []string{"loglevel"},
+		Env: "DEV_HEALTH_LOG_LEVEL", Kind: KindString,
+		Default: "info", Group: GroupRuntime,
+		Usage: "debug, info, warn, or error",
+	},
+	{
+		Flag: "environment", Env: devHealthEnv, Kind: KindString, Group: GroupRuntime,
+		Usage: "deployment environment name; GO_PROVIDER_ROUTES=all requires local",
+	},
+	{
+		Flag: "stream-replicas", Env: "DEV_HEALTH_STREAM_REPLICAS", Kind: KindInt,
+		Default: "1", Group: GroupRuntime,
+		Usage: "configured replica count of this stream family (1-8)",
+	},
+
+	// The CHAOS-4005 unreclaimable-dispatching sweep. Reconciler-only: this is
+	// the per-binary scope the registry exists to express, so the flag never
+	// appears in another binary's --help. Flag name, enum, environment
+	// fallback, and the active-is-a-declaration warning are preserved exactly
+	// as CHAOS-4005 shipped them; only the resolution path changed, from a
+	// private flag>env branch to the shared layered lookup.
+	{
+		Flag: "unreclaimable-sweep", Env: "SYNC_UNRECLAIMABLE_SWEEP",
+		Kind: KindString, Default: "shadow",
+		Services: []string{"dev-health-reconciler"}, Group: GroupRuntime,
+		Usage: "unreclaimable dispatch sweep: off|shadow|active (default shadow). " +
+			"Setting active asserts that no Celery consumer serves provider " +
+			"units for this deployment",
+	},
+
+	// Database and River.
+	{
+		Flag: "queue-database-mode", Env: "WORKER_DATABASE_MODE", Kind: KindString,
+		Default: string(QueueControlDirect), Group: GroupDatabase,
+		Usage: "queue-control endpoint semantics: direct, session, or transaction",
+	},
+	{
+		Flag: "coordinator-database-mode", Env: "COORDINATOR_DATABASE_MODE", Kind: KindString,
+		Default: string(QueueControlDirect), Group: GroupDatabase,
+		Usage: "coordinator endpoint semantics: direct, session, or transaction",
+	},
+	{
+		Flag: "domain-transaction-pooler", Env: "PGBOUNCER_TRANSACTION_MODE", Kind: KindBool,
+		Default: "false", Group: GroupDatabase,
+		Usage: "the domain DSN points at a transaction-pooling PgBouncer",
+	},
+	{
+		Flag: "river-schema", Env: "RIVER_DATABASE_SCHEMA", Kind: KindString,
+		Default: defaultRiverDatabaseSchema, Group: GroupDatabase,
+		Usage: "PostgreSQL schema holding the River job tables",
+	},
+	{
+		Flag: "domain-database-role", Env: "RIVER_DOMAIN_DATABASE_ROLE", Kind: KindString,
+		Default: defaultDomainDatabaseRole, Group: GroupDatabase,
+		Usage: "PostgreSQL role for the domain pool",
+	},
+	{
+		Flag: "queue-database-role", Env: "RIVER_QUEUE_DATABASE_ROLE", Kind: KindString,
+		Default: defaultQueueDatabaseRole, Group: GroupDatabase,
+		Usage: "PostgreSQL role for the queue-control pool",
+	},
+	{
+		Flag: "coordinator-database-role", Env: "RIVER_COORDINATOR_DATABASE_ROLE", Kind: KindString,
+		Default: defaultCoordinatorDatabaseRole, Group: GroupDatabase,
+		Usage: "PostgreSQL role for the coordinator pool",
+	},
+	{
+		Flag: "domain-max-conns", Env: "WORKER_DOMAIN_DATABASE_MAX_CONNS", Kind: KindInt,
+		Default: "4", Group: GroupDatabase,
+		Usage: "domain pool connection ceiling (1-16)",
+	},
+	{
+		Flag: "queue-max-conns", Env: "WORKER_DATABASE_MAX_CONNS", Kind: KindInt,
+		Default: "2", Group: GroupDatabase,
+		Usage: "queue-control pool connection ceiling (1-4)",
+	},
+	{
+		Flag: "coordinator-max-conns", Env: "WORKER_COORDINATOR_DATABASE_MAX_CONNS", Kind: KindInt,
+		Default: "2", Group: GroupDatabase,
+		Usage: "coordinator pool connection ceiling (1-4)",
+	},
+	{
+		Flag: "completed-job-retention", Env: "RIVER_COMPLETED_JOB_RETENTION", Kind: KindDuration,
+		Default: defaultCompletedRetention.String(), Group: GroupDatabase,
+		Usage: "how long completed River jobs are kept (24h-8760h)",
+	},
+	{
+		Flag: "cancelled-job-retention", Env: "RIVER_CANCELLED_JOB_RETENTION", Kind: KindDuration,
+		Default: defaultCancelledRetention.String(), Group: GroupDatabase,
+		Usage: "how long cancelled River jobs are kept (24h-8760h)",
+	},
+	{
+		Flag: "discarded-job-retention", Env: "RIVER_DISCARDED_JOB_RETENTION", Kind: KindDuration,
+		Default: defaultDiscardedRetention.String(), Group: GroupDatabase,
+		Usage: "how long discarded River jobs are kept (24h-8760h)",
+	},
+	{
+		Flag: "job-cleaner-timeout", Env: "RIVER_JOB_CLEANER_TIMEOUT", Kind: KindDuration,
+		Default: defaultJobCleanerTimeout.String(), Group: GroupDatabase,
+		Usage: "per-run timeout of the River job cleaner (5s-5m)",
+	},
+
+	// Provider routes.
+	{
+		Flag: "github-work-items-status-mapping",
+		Env:  "WORKER_GITHUB_WORK_ITEMS_STATUS_MAPPING_PATH",
+		Kind: KindString, Group: GroupRoutes,
+		Usage: "path to status_mapping.yaml; required when github/work-items is enabled",
+	},
+	{
+		Flag: "github-work-items-investment-config",
+		Env:  "WORKER_GITHUB_WORK_ITEMS_INVESTMENT_CONFIG_PATH",
+		Kind: KindString, Group: GroupRoutes,
+		Usage: "path to investment_areas.yaml; required when github/work-items is enabled",
+	},
+	{
+		Flag: "pagerduty-webhook-transport", Env: "PAGERDUTY_WEBHOOK_TRANSPORT", Kind: KindString,
+		Default: PagerDutyTransportCelery, Group: GroupRoutes,
+		Usage: "owner of the PagerDuty webhook stream: celery or river",
+	},
+
+	// Operational bridge.
+	{
+		Flag: "operational-bridge-url", Env: "WORKER_OPERATIONAL_BRIDGE_URL", Kind: KindString,
+		Group: GroupBridge,
+		Usage: "base URL of the Python operational bridge",
+	},
+	{
+		Flag: "operational-bridge-timeout", Env: "WORKER_OPERATIONAL_BRIDGE_TIMEOUT", Kind: KindDuration,
+		Default: "10s", Group: GroupBridge,
+		Usage: "operational bridge request timeout (100ms-30s)",
+	},
+	{
+		Flag: "operational-bridge-allow-insecure", Env: "WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE",
+		Kind: KindBool, Default: "false", Group: GroupBridge,
+		Usage: "permit a plaintext operational bridge origin",
+	},
+
+	// Credentials: environment only, on purpose.
+	{Env: "POSTGRES_URI", Secret: true, Group: GroupCredentials, Usage: "domain PostgreSQL DSN"},
+	{Env: "WORKER_DATABASE_URI", Secret: true, Group: GroupCredentials, Usage: "queue-control PostgreSQL DSN"},
+	{Env: "COORDINATOR_DATABASE_URI", Secret: true, Group: GroupCredentials, Usage: "coordinator PostgreSQL DSN; required by coordinator binaries"},
+	{Env: "CLICKHOUSE_URI", Secret: true, Group: GroupCredentials, Usage: "ClickHouse DSN; native protocol, port 9000"},
+	{Env: "VALKEY_URI", Secret: true, Group: GroupCredentials, Usage: "Valkey/Redis DSN"},
+	{Env: "SETTINGS_ENCRYPTION_KEY", Secret: true, Group: GroupCredentials, Usage: "provider credential encryption key"},
+	{Env: "SETTINGS_ENCRYPTION_SALT", Secret: true, Group: GroupCredentials, Usage: "provider credential encryption salt"},
+	{Env: "PAGER_DUTY_CLIENT_ID", Secret: true, Group: GroupCredentials, Usage: "PagerDuty OAuth client id"},
+	{Env: "PAGER_DUTY_SECRET", Secret: true, Group: GroupCredentials, Usage: "PagerDuty OAuth client secret"},
+	{Env: "WORKER_OPERATIONAL_BRIDGE_TOKEN", Secret: true, Group: GroupCredentials, Usage: "operational bridge bearer token"},
+}
+
+// Options returns every declared option in registry order.
+func Options() []Option {
+	return slices.Clone(optionRegistry)
+}
+
+// AppliesTo reports whether this option is offered by the named service.
+func (o Option) AppliesTo(service string, requireQueues bool) bool {
+	if o.QueueOnly && !requireQueues {
+		return false
+	}
+	if len(o.Services) > 0 && !slices.Contains(o.Services, service) {
+		return false
+	}
+	return true
+}
+
+// OptionsFor returns the options a service exposes, in --help display order.
+func OptionsFor(service string, requireQueues bool) []Option {
+	selected := make([]Option, 0, len(optionRegistry))
+	for _, option := range optionRegistry {
+		if option.AppliesTo(service, requireQueues) {
+			selected = append(selected, option)
+		}
+	}
+	slices.SortStableFunc(selected, func(a, b Option) int {
+		return slices.Index(groupOrder, a.Group) - slices.Index(groupOrder, b.Group)
+	})
+	return selected
+}
+
+// optionByEnv indexes the registry by environment-variable name.
+var optionByEnv = func() map[string]Option {
+	index := make(map[string]Option, len(optionRegistry))
+	for _, option := range optionRegistry {
+		if option.Env != "" {
+			index[option.Env] = option
+		}
+	}
+	return index
+}()
+
+// settingLabel renders the operator-facing name of a setting for error
+// messages. Naming both the canonical flag and the environment fallback means
+// one message serves an operator who configured either surface, which matters
+// most during the migration when a deployment mixes the two.
+func settingLabel(env string) string {
+	option, known := optionByEnv[env]
+	if !known || option.Flag == "" {
+		return env
+	}
+	return fmt.Sprintf("--%s (%s)", option.Flag, env)
+}
+
+// EnvNames returns every environment variable the registry reads, sorted. It
+// backs the deployment-surface contract tests.
+func EnvNames() []string {
+	names := make([]string, 0, len(optionRegistry)+len(routeRegistry))
+	for _, option := range optionRegistry {
+		if option.Env != "" {
+			names = append(names, option.Env)
+		}
+	}
+	for _, route := range routeRegistry {
+		names = append(names, route.Env)
+	}
+	slices.Sort(names)
+	return slices.Compact(names)
+}
+
+// FlagNames returns every canonical long flag the registry offers, sorted.
+func FlagNames() []string {
+	names := make([]string, 0, len(optionRegistry))
+	for _, option := range optionRegistry {
+		if option.Flag != "" {
+			names = append(names, option.Flag)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+// RequiredEnvironment lists the settings that have no flag and must therefore
+// still be supplied through the environment. This is the "documented handful"
+// a standard deployment configures.
+func RequiredEnvironment() []string {
+	names := make([]string, 0, 16)
+	for _, option := range optionRegistry {
+		if option.Secret {
+			names = append(names, option.Env)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+// HelpText renders the full --help body for one service.
+func HelpText(service string, requireQueues bool) string {
+	var out strings.Builder
+	fmt.Fprintf(&out, "Usage: %s [options]\n\n", service)
+	out.WriteString(
+		"Configuration is flag-first: every option below may also be supplied through\n" +
+			"its environment variable, and a flag always wins over the environment.\n" +
+			"An unknown flag is rejected at startup rather than ignored.\n",
+	)
+
+	options := OptionsFor(service, requireQueues)
+	currentGroup := ""
+	for _, option := range options {
+		if option.Group != currentGroup {
+			currentGroup = option.Group
+			fmt.Fprintf(&out, "\n%s:\n", strings.ToUpper(currentGroup))
+		}
+		out.WriteString(optionHelpLine(option))
+	}
+
+	// The forty WORKER_*_ENABLED provider route switches are deliberately not
+	// listed as options: they have no flag. What a worker executes follows
+	// from the queues it consumes, and the switches survive only so the Python
+	// planner and the Go executor agree about what to plan.
+	out.WriteString(
+		"\nPROVIDER ROUTE SWITCHES:\n" +
+			"  Environment only, and not selected here. A worker executes the queues it\n" +
+			"  is told to consume with --queues; the WORKER_<PROVIDER>_<DATASET>_ENABLED\n" +
+			"  variables remain the producer/executor agreement and are documented in\n" +
+			"  docs/operate/run/workers-and-jobs.md.\n",
+	)
+	return out.String()
+}
+
+// optionHelpLine renders one option, its value placeholder, its environment
+// fallback, and its default.
+func optionHelpLine(option Option) string {
+	var out strings.Builder
+	if option.Secret {
+		fmt.Fprintf(&out, "  %-42s %s\n", option.Env, option.Usage)
+		fmt.Fprintf(&out, "  %-42s %s\n", "", "(environment only: never accepted as a flag)")
+		return out.String()
+	}
+	name := "--" + option.Flag
+	if option.Short != "" {
+		name = "-" + option.Short + ", " + name
+	}
+	name += " " + option.Kind.Placeholder()
+	usage := option.Usage
+	if len(option.Aliases) > 0 {
+		aliases := make([]string, 0, len(option.Aliases))
+		for _, alias := range option.Aliases {
+			dash := "--"
+			if len(alias) == 1 {
+				dash = "-"
+			}
+			aliases = append(aliases, dash+alias)
+		}
+		usage += fmt.Sprintf(" (alias: %s)", strings.Join(aliases, ", "))
+	}
+	fmt.Fprintf(&out, "  %-42s %s\n", name, usage)
+	detail := ""
+	switch {
+	case option.Env != "" && option.Default != "":
+		detail = fmt.Sprintf("env %s, default %s", option.Env, option.Default)
+	case option.Env != "":
+		detail = fmt.Sprintf("env %s", option.Env)
+	case option.Default != "":
+		detail = fmt.Sprintf("default %s", option.Default)
+	}
+	if detail != "" {
+		fmt.Fprintf(&out, "  %-42s [%s]\n", "", detail)
+	}
+	return out.String()
+}

--- a/internal/platform/config/options_test.go
+++ b/internal/platform/config/options_test.go
@@ -1,0 +1,235 @@
+package config
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestEveryNonSecretSettingIsReachableFromHelp is the acceptance test for
+// "a new operator can configure a worker from --help alone". Every environment
+// variable the configuration layer reads must appear in --help, either as a
+// flag or as a documented environment-only credential. A setting that reaches
+// Load without being declared here is exactly the unfindable variable this
+// ticket removes.
+func TestEveryNonSecretSettingIsReachableFromHelp(t *testing.T) {
+	t.Parallel()
+
+	help := HelpText("dev-health-worker", true)
+	for _, option := range optionRegistry {
+		if !option.AppliesTo("dev-health-worker", true) {
+			continue
+		}
+		if option.Secret {
+			if !strings.Contains(help, option.Env) {
+				t.Errorf("credential %s is not documented in --help", option.Env)
+			}
+			continue
+		}
+		if !strings.Contains(help, "--"+option.Flag) {
+			t.Errorf("option %s has no --help entry", option.Flag)
+		}
+		if option.Env != "" && !strings.Contains(help, option.Env) {
+			t.Errorf("option %s does not document its %s fallback", option.Flag, option.Env)
+		}
+	}
+	// The forty provider route switches are environment-only and have no flag,
+	// so --help must NOT advertise them as options; it says where they live.
+	if !strings.Contains(help, "PROVIDER ROUTE SWITCHES:") {
+		t.Error("--help must say where the environment-only route switches are documented")
+	}
+}
+
+// TestHelpDeclaresTheDocumentedEnvironmentHandful pins the acceptance
+// criterion that a standard deployment configures a handful of variables rather
+// than the eighty-five the binaries read today. The handful is the credential
+// set, which stays in the environment on purpose.
+func TestHelpDeclaresTheDocumentedEnvironmentHandful(t *testing.T) {
+	t.Parallel()
+
+	required := RequiredEnvironment()
+	if len(required) > 12 {
+		t.Fatalf("required environment grew to %d settings: %v", len(required), required)
+	}
+	for _, name := range required {
+		option, declared := optionByEnv[name]
+		if !declared || !option.Secret {
+			t.Errorf("%s is reported as required environment but is not a declared credential", name)
+		}
+	}
+	// Anything the registry reads that is not a credential must have a flag.
+	for _, name := range EnvNames() {
+		if slices.Contains(required, name) {
+			continue
+		}
+		option, declared := optionByEnv[name]
+		if declared && option.Flag == "" {
+			t.Errorf("%s has neither a flag nor credential status", name)
+		}
+	}
+}
+
+// TestCredentialsAreNeverOfferedAsFlags keeps DSNs and tokens off the command
+// line. Process arguments are visible through `ps` and `docker inspect`, and
+// `docker compose config` renders a command: verbatim -- the very output this
+// ticket asks operators to read.
+func TestCredentialsAreNeverOfferedAsFlags(t *testing.T) {
+	t.Parallel()
+
+	for _, option := range optionRegistry {
+		if option.Secret && (option.Flag != "" || option.Short != "") {
+			t.Errorf("credential %s must not be offered as a flag", option.Env)
+		}
+	}
+}
+
+// TestOptionRegistryIsInternallyConsistent guards the registry itself: a
+// duplicated flag name would silently make one declaration unreachable, and a
+// duplicated environment name would make the override map ambiguous.
+func TestOptionRegistryIsInternallyConsistent(t *testing.T) {
+	t.Parallel()
+
+	flags := map[string]bool{}
+	envs := map[string]bool{}
+	for _, option := range optionRegistry {
+		if option.Flag != "" {
+			if flags[option.Flag] {
+				t.Errorf("flag --%s is declared more than once", option.Flag)
+			}
+			flags[option.Flag] = true
+		}
+		for _, alias := range option.Aliases {
+			if flags[alias] {
+				t.Errorf("flag --%s is declared more than once", alias)
+			}
+			flags[alias] = true
+		}
+		if option.Short != "" {
+			if flags[option.Short] {
+				t.Errorf("short flag -%s is declared more than once", option.Short)
+			}
+			flags[option.Short] = true
+		}
+		if option.Env != "" {
+			if envs[option.Env] {
+				t.Errorf("environment name %s is declared more than once", option.Env)
+			}
+			envs[option.Env] = true
+		}
+		if option.Usage == "" {
+			t.Errorf("option %s%s has no usage text", option.Flag, option.Env)
+		}
+		if !slices.Contains(groupOrder, option.Group) {
+			t.Errorf("option %s%s has unknown help group %q", option.Flag, option.Env, option.Group)
+		}
+	}
+	if !flags["queue-concurrency"] {
+		t.Error("--queue-concurrency must survive as an alias: manifests outside this repository still pass it")
+	}
+}
+
+// TestSettingLabelNamesBothSurfaces keeps configuration errors useful during
+// the migration, when one deployment may be configured by flag and another by
+// environment.
+func TestSettingLabelNamesBothSurfaces(t *testing.T) {
+	t.Parallel()
+
+	if got := settingLabel("WORKER_DATABASE_MODE"); got != "--queue-database-mode (WORKER_DATABASE_MODE)" {
+		t.Fatalf("settingLabel = %q", got)
+	}
+	// A credential has no flag, so its own name is the whole label.
+	if got := settingLabel("POSTGRES_URI"); got != "POSTGRES_URI" {
+		t.Fatalf("credential label = %q, want the bare variable name", got)
+	}
+	if got := settingLabel("NOT_DECLARED"); got != "NOT_DECLARED" {
+		t.Fatalf("undeclared label = %q", got)
+	}
+}
+
+// TestOptionsForRespectsServiceScope proves the registry can carry a
+// single-binary option without that flag leaking into every other binary's
+// --help. This is the extension point a reconciler-only or scheduler-only knob
+// uses.
+func TestOptionsForRespectsServiceScope(t *testing.T) {
+	t.Parallel()
+
+	worker := HelpText("dev-health-worker", true)
+	if strings.Contains(worker, "--profile") {
+		t.Error("dev-health-worker must not advertise --profile")
+	}
+	if !strings.Contains(worker, "-Q, --queues") {
+		t.Error("a queue-consuming binary must advertise -Q/--queues")
+	}
+
+	runner := HelpText("dev-health-stream-runner", false)
+	if !strings.Contains(runner, "--profile") {
+		t.Error("dev-health-stream-runner must advertise --profile")
+	}
+	if strings.Contains(runner, "-Q, --queues") {
+		t.Error("a binary that consumes no queues must not advertise -Q/--queues")
+	}
+}
+
+func TestHelpTextIsStableAndSelfDescribing(t *testing.T) {
+	t.Parallel()
+
+	help := HelpText("dev-health-worker", true)
+	for _, fragment := range []string{
+		"Usage: dev-health-worker [options]",
+		"a flag always wins over the environment",
+		"An unknown flag is rejected at startup",
+		strings.ToUpper(GroupWorker) + ":",
+		strings.ToUpper(GroupCredentials) + ":",
+		"environment only: never accepted as a flag",
+	} {
+		if !strings.Contains(help, fragment) {
+			t.Errorf("--help is missing %q", fragment)
+		}
+	}
+	if !strings.Contains(help, "-Q, --queues") || !strings.Contains(help, "-c, --concurrency") {
+		t.Error("--help must advertise the Celery short forms")
+	}
+}
+
+func TestFlagNamesAreShellSafe(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range FlagNames() {
+		if name != strings.ToLower(name) || strings.ContainsAny(name, " _=") {
+			t.Errorf("flag %q is not a lowercase dash-separated name", name)
+		}
+	}
+	if len(FlagNames()) == 0 {
+		t.Fatal("registry declares no flags")
+	}
+}
+
+// TestUnreclaimableSweepIsReconcilerScoped proves the registry's per-binary
+// scope does real work: CHAOS-4005's flag must appear in the reconciler's
+// --help and in no other binary's, and it must keep the exact enum, fallback,
+// and active-is-a-declaration warning that ticket shipped.
+func TestUnreclaimableSweepIsReconcilerScoped(t *testing.T) {
+	t.Parallel()
+
+	reconciler := HelpText("dev-health-reconciler", false)
+	if !strings.Contains(reconciler, "--unreclaimable-sweep") {
+		t.Fatal("the reconciler must advertise --unreclaimable-sweep")
+	}
+	for _, fragment := range []string{
+		"off|shadow|active",
+		"default shadow",
+		"Setting active asserts that no Celery consumer serves provider units for this deployment",
+		"SYNC_UNRECLAIMABLE_SWEEP",
+	} {
+		if !strings.Contains(reconciler, fragment) {
+			t.Errorf("--unreclaimable-sweep help lost %q", fragment)
+		}
+	}
+	for _, service := range []string{
+		"dev-health-worker", "dev-health-scheduler", "dev-health-stream-runner",
+	} {
+		if strings.Contains(HelpText(service, service == "dev-health-worker"), "--unreclaimable-sweep") {
+			t.Errorf("%s must not advertise the reconciler's sweep flag", service)
+		}
+	}
+}

--- a/internal/platform/config/resolve.go
+++ b/internal/platform/config/resolve.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
+)
+
+// layeredLookup returns a lookup that resolves flag overrides before the
+// process environment. Every existing resolution helper takes a
+// secrets.LookupEnv, so layering here gives the whole configuration surface
+// flag > env > default precedence without each site learning about flags.
+func layeredLookup(overrides map[string]string, environment secrets.LookupEnv) secrets.LookupEnv {
+	if len(overrides) == 0 {
+		return environment
+	}
+	return func(key string) (string, bool) {
+		if value, present := overrides[key]; present {
+			return value, true
+		}
+		return environment(key)
+	}
+}
+
+// validateOverrides rejects an override for a setting that has no flag.
+//
+// Secrets are environment-only by design: a DSN or token passed as a process
+// argument is readable through `ps`, `docker inspect`, and the `docker compose
+// config` output this ticket asks operators to read. The flag layer never
+// produces such an override, so reaching this error means a caller constructed
+// a Spec by hand and the guard keeps that from quietly becoming a supported
+// path.
+func validateOverrides(overrides map[string]string) error {
+	names := make([]string, 0, len(overrides))
+	for key := range overrides {
+		names = append(names, key)
+	}
+	slices.Sort(names)
+	for _, key := range names {
+		option, declared := optionByEnv[key]
+		if !declared {
+			return fmt.Errorf("%s is not a declared configuration setting", key)
+		}
+		if option.Secret {
+			return fmt.Errorf(
+				"%s is a credential and must be supplied through the environment, not a flag",
+				key,
+			)
+		}
+	}
+	return nil
+}
+
+// settingConfigured reports whether an operator supplied a value for a setting
+// through either surface, as opposed to the package default applying.
+func settingConfigured(lookup secrets.LookupEnv, key string) bool {
+	value, present := lookup(key)
+	return present && strings.TrimSpace(value) != ""
+}
+
+// envOnlySettings names the settings this process took from the environment
+// even though a canonical flag exists.
+//
+// It is deliberately computed against the raw environment rather than the
+// layered lookup: the question is which surface the operator actually used, and
+// the layered lookup exists precisely to erase that difference everywhere else.
+func envOnlySettings(spec Spec, environment secrets.LookupEnv) []string {
+	names := make([]string, 0, 8)
+	for _, option := range optionRegistry {
+		if option.Secret || option.Env == "" || option.Flag == "" {
+			continue
+		}
+		if !option.AppliesTo(spec.Service, spec.RequireQueues) {
+			continue
+		}
+		if _, overridden := spec.Overrides[option.Env]; overridden {
+			continue
+		}
+		if settingConfigured(environment, option.Env) {
+			names = append(names, option.Flag)
+		}
+	}
+	slices.Sort(names)
+	return slices.Compact(names)
+}

--- a/internal/platform/config/routes.go
+++ b/internal/platform/config/routes.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
+)
+
+// Route names one provider-dataset pair the worker can be told to serve.
+//
+// These forty switches are ENVIRONMENT ONLY and deliberately have no flag.
+// Selection-by-subscription is the model: what a worker executes follows from
+// the queues it consumes (-Q/--queues), not from a parallel forty-switch
+// enablement surface. The switches remain because the Python planner reads the
+// identical WORKER_*_ENABLED names through ProviderUnitRouteSwitches to decide
+// what to plan, and a producer and executor that disagree about a route
+// dispatch units to a worker with no handler.
+//
+// This registry exists so that agreement is greppable in one place rather than
+// spread through a 182-line literal inside Load. It is the deprecation map for
+// the eventual move to subscription.
+type Route struct {
+	// Env is the switch name, shared verbatim with the Python producer.
+	Env string
+	// target locates this route's switch inside a Config.
+	target func(*Config) *bool
+}
+
+// routeRegistry is the one place a provider route switch is declared.
+var routeRegistry = []Route{
+	{Env: "WORKER_GITHUB_BLAME_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubBlameEnabled }},
+	{Env: "WORKER_GITHUB_CICD_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubCICDEnabled }},
+	{Env: "WORKER_GITHUB_COMMIT_STATS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubCommitStatsEnabled }},
+	{Env: "WORKER_GITHUB_COMMITS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubCommitsEnabled }},
+	{Env: "WORKER_GITHUB_DEPLOYMENTS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubDeploymentsEnabled }},
+	{Env: "WORKER_GITHUB_FILES_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubFilesEnabled }},
+	{Env: "WORKER_GITHUB_PR_COMMENTS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubPRCommentsEnabled }},
+	{Env: "WORKER_GITHUB_PR_REVIEWS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubPRReviewsEnabled }},
+	{Env: "WORKER_GITHUB_PRS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubPRsEnabled }},
+	{Env: "WORKER_GITHUB_REPO_METADATA_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubRepoMetadataEnabled }},
+	{Env: "WORKER_GITHUB_SECURITY_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubSecurityEnabled }},
+	{Env: "WORKER_GITHUB_TESTS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubTestsEnabled }},
+	{Env: "WORKER_GITHUB_WORK_ITEMS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGithubWorkItemsEnabled }},
+	{Env: "WORKER_GITLAB_BLAME_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabBlameEnabled }},
+	{Env: "WORKER_GITLAB_CICD_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabCICDEnabled }},
+	{Env: "WORKER_GITLAB_COMMIT_STATS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabCommitStatsEnabled }},
+	{Env: "WORKER_GITLAB_COMMITS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabCommitsEnabled }},
+	{Env: "WORKER_GITLAB_DEPLOYMENTS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabDeploymentsEnabled }},
+	{Env: "WORKER_GITLAB_FEATURE_FLAGS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabFeatureFlagsEnabled }},
+	{Env: "WORKER_GITLAB_FILES_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabFilesEnabled }},
+	{Env: "WORKER_GITLAB_INCIDENTS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabIncidentsEnabled }},
+	{Env: "WORKER_GITLAB_PR_COMMENTS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabPRCommentsEnabled }},
+	{Env: "WORKER_GITLAB_PR_REVIEWS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabPRReviewsEnabled }},
+	{Env: "WORKER_GITLAB_PRS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabPRsEnabled }},
+	{Env: "WORKER_GITLAB_REPO_METADATA_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabRepoMetadataEnabled }},
+	{Env: "WORKER_GITLAB_SECURITY_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabSecurityEnabled }},
+	{Env: "WORKER_GITLAB_TESTS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabTestsEnabled }},
+	{Env: "WORKER_GITLAB_WORK_ITEMS_ENABLED", target: func(c *Config) *bool { return &c.WorkerGitlabWorkItemsEnabled }},
+	{Env: "WORKER_JIRA_INCIDENTS_ENABLED", target: func(c *Config) *bool { return &c.WorkerJiraIncidentsEnabled }},
+	{Env: "WORKER_JIRA_WORK_ITEMS_ENABLED", target: func(c *Config) *bool { return &c.WorkerJiraWorkItemsEnabled }},
+	{Env: "WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED", target: func(c *Config) *bool { return &c.WorkerLaunchDarklyFeatureFlagsEnabled }},
+	{Env: "WORKER_LINEAR_WORK_ITEMS_ENABLED", target: func(c *Config) *bool { return &c.WorkerLinearWorkItemsEnabled }},
+	{Env: "WORKER_PAGERDUTY_BUSINESS_SERVICES_ENABLED", target: func(c *Config) *bool { return &c.WorkerPagerDutyBusinessServicesEnabled }},
+	{Env: "WORKER_PAGERDUTY_ESCALATION_POLICIES_ENABLED", target: func(c *Config) *bool { return &c.WorkerPagerDutyEscalationPoliciesEnabled }},
+	{Env: "WORKER_PAGERDUTY_INCIDENTS_ENABLED", target: func(c *Config) *bool { return &c.WorkerPagerDutyIncidentsEnabled }},
+	{Env: "WORKER_PAGERDUTY_ON_CALLS_ENABLED", target: func(c *Config) *bool { return &c.WorkerPagerDutyOnCallsEnabled }},
+	{Env: "WORKER_PAGERDUTY_SCHEDULES_ENABLED", target: func(c *Config) *bool { return &c.WorkerPagerDutySchedulesEnabled }},
+	{Env: "WORKER_PAGERDUTY_SERVICES_ENABLED", target: func(c *Config) *bool { return &c.WorkerPagerDutyServicesEnabled }},
+	{Env: "WORKER_PAGERDUTY_TEAMS_ENABLED", target: func(c *Config) *bool { return &c.WorkerPagerDutyTeamsEnabled }},
+	{Env: "WORKER_PAGERDUTY_USERS_ENABLED", target: func(c *Config) *bool { return &c.WorkerPagerDutyUsersEnabled }},
+}
+
+// Routes returns the declared provider route switches.
+func Routes() []Route {
+	return slices.Clone(routeRegistry)
+}
+
+// applyRoutes resolves every route switch from the environment.
+func applyRoutes(cfg *Config, lookup secrets.LookupEnv, allProviderRoutes bool) error {
+	for _, route := range routeRegistry {
+		fallback := false
+		if allProviderRoutes {
+			presetDefault, err := providerRoutePresetDefault(lookup, route.Env)
+			if err != nil {
+				return err
+			}
+			fallback = presetDefault
+		}
+		value, err := boolEnv(lookup, route.Env, fallback)
+		if err != nil {
+			return err
+		}
+		*route.target(cfg) = value
+	}
+	return nil
+}
+
+// EnabledRouteNames reports the route switches this configuration enables, for
+// startup evidence.
+func (c Config) EnabledRouteNames() []string {
+	enabled := make([]string, 0, len(routeRegistry))
+	for _, route := range routeRegistry {
+		if *route.target(&c) {
+			enabled = append(enabled, route.Env)
+		}
+	}
+	slices.Sort(enabled)
+	return enabled
+}
+
+// environmentIsLocal reports whether this process is configured as a local
+// deployment, the one place the all-routes preset is permitted.
+func environmentIsLocal(lookup secrets.LookupEnv) bool {
+	environment, _ := lookup(devHealthEnv)
+	return strings.ToLower(strings.TrimSpace(environment)) == "local"
+}

--- a/internal/platform/shell/shell.go
+++ b/internal/platform/shell/shell.go
@@ -42,14 +42,10 @@ type ConfigureDependenciesWithLogger func(
 ) ([]lifecycle.Component, error)
 
 type Spec struct {
-	Service        string
-	Profiles       []string
-	DefaultProfile string
-	RequireQueues  bool
-	// UnreclaimableSweep registers --unreclaimable-sweep for services that own
-	// the CHAOS-4005 safety net. Flag-first with an env fallback, per
-	// CHAOS-4020's direction away from per-knob environment variables.
-	UnreclaimableSweep              bool
+	Service                         string
+	Profiles                        []string
+	DefaultProfile                  string
+	RequireQueues                   bool
 	ConfigureDependencies           ConfigureDependencies
 	ConfigureDependenciesWithLogger ConfigureDependenciesWithLogger
 }
@@ -59,15 +55,100 @@ type IO struct {
 	Stderr io.Writer
 }
 
-type repeatedStringFlag []string
-
-func (values *repeatedStringFlag) String() string {
-	return fmt.Sprint([]string(*values))
+// optionValue is the flag.Value backing every declared option.
+//
+// It deliberately stores the raw string rather than parsing here: the very same
+// value can arrive through the option's environment fallback, and one parser at
+// one site (config.Load) is what keeps a flag and its variable from disagreeing
+// about what "16m" or "true" means. Parse errors surface from there naming both
+// surfaces.
+type optionValue struct {
+	kind       config.Kind
+	repeatable bool
+	raw        string
+	set        bool
 }
 
-func (values *repeatedStringFlag) Set(value string) error {
-	*values = append(*values, value)
+func (value *optionValue) String() string {
+	if value == nil {
+		return ""
+	}
+	return value.raw
+}
+
+func (value *optionValue) Set(raw string) error {
+	if value.repeatable && value.set {
+		value.raw += "," + raw
+	} else {
+		value.raw = raw
+	}
+	value.set = true
 	return nil
+}
+
+// IsBoolFlag lets the flag package accept a bare --flag for boolean options
+// while still honoring the explicit --flag=false form.
+func (value *optionValue) IsBoolFlag() bool { return value.kind == config.KindBool }
+
+// registerOptions binds every option this service offers onto flags and returns
+// the bound values keyed by canonical flag name. A short alias is registered
+// against the same value, so -q and --queues are one setting rather than two
+// that could disagree.
+func registerOptions(flags *flag.FlagSet, spec Spec) map[string]*optionValue {
+	bound := make(map[string]*optionValue)
+	for _, option := range config.OptionsFor(spec.Service, spec.RequireQueues) {
+		if option.Secret {
+			continue
+		}
+		// Profiles are declared by the Spec, not by the registry's service
+		// list; a binary that declares none must not advertise the flag.
+		if option.Flag == "profile" && len(spec.Profiles) == 0 {
+			continue
+		}
+		value := &optionValue{
+			kind: option.Kind,
+			// Queue topology is the one place operators habitually repeat a
+			// flag instead of writing one comma-separated value.
+			repeatable: option.Flag == "queues" || option.Flag == "concurrency",
+		}
+		flags.Var(value, option.Flag, option.Usage)
+		if option.Short != "" {
+			flags.Var(value, option.Short, option.Usage)
+		}
+		for _, alias := range option.Aliases {
+			flags.Var(value, alias, option.Usage)
+		}
+		bound[option.Flag] = value
+	}
+	return bound
+}
+
+// overridesFrom collects the options the operator actually supplied, keyed by
+// the environment variable each one shadows. Only options that were set appear,
+// which is what makes the environment a fallback rather than a competitor.
+//
+// A flag whose value is blank ("--shutdown-timeout=") counts as NOT supplied
+// and is omitted, so the environment still resolves beneath it. Every
+// resolution site in config treats a blank value as unset -- envOrDefault,
+// durationEnv, boolEnv, and the durationArgumentOrEnv this replaced all trim
+// and fall through -- so an empty flag that shadowed a real environment value
+// would be the one place in the surface where blank meant "override with
+// nothing". That would silently drop a deployment's shutdown budget to the
+// package default and flip ShutdownTimeoutExplicit, which feeds the worker's
+// drain-budget decision.
+func overridesFrom(bound map[string]*optionValue) map[string]string {
+	overrides := make(map[string]string)
+	for _, option := range config.Options() {
+		value, registered := bound[option.Flag]
+		if !registered || !value.set || option.Env == "" {
+			continue
+		}
+		if strings.TrimSpace(value.raw) == "" {
+			continue
+		}
+		overrides[option.Env] = value.raw
+	}
+	return overrides
 }
 
 // resolveProfile owns runtime-profile selection end to end (CHAOS-3875). Only
@@ -105,6 +186,24 @@ func resolveProfile(
 	return chosen, nil
 }
 
+// warnEnvOnlySettings reports configuration that arrived through an
+// environment variable although a canonical flag exists for it.
+//
+// The environment fallback is retained for 12-factor compatibility and to make
+// the migration incremental, but a deployment still configured that way is not
+// visible in `docker compose config`, so it is worth one warning per start
+// rather than silence.
+func warnEnvOnlySettings(logger *slog.Logger, cfg config.Config) {
+	if len(cfg.EnvOnlySettings) == 0 {
+		return
+	}
+	logger.Warn(
+		"configuration supplied through environment variables",
+		"settings", strings.Join(cfg.EnvOnlySettings, ","),
+		"guidance", "pass these as flags in the deployed command so the configuration is visible where it is deployed",
+	)
+}
+
 // Main runs a production command and exits with its status.
 func Main(spec Spec) {
 	os.Exit(Execute(context.Background(), spec, os.Args[1:], os.LookupEnv, IO{
@@ -137,44 +236,36 @@ func Execute(
 
 	flags := flag.NewFlagSet(spec.Service, flag.ContinueOnError)
 	flags.SetOutput(streams.Stdout)
+	// --help is the single discovery surface for this binary's configuration
+	// (CHAOS-4020), so it is rendered from the option registry rather than from
+	// the flag package's own defaults listing: the registry is what carries the
+	// environment fallback names, the documented defaults, and the route
+	// vocabulary.
+	flags.Usage = func() {
+		fmt.Fprint(streams.Stdout, config.HelpText(spec.Service, spec.RequireQueues))
+	}
 	showVersion := flags.Bool("version", false, "print build metadata as JSON and exit")
-	var selectedProfile *string
-	var selectedQueues repeatedStringFlag
-	var queueConcurrency repeatedStringFlag
-	var workerGroup, shutdownTimeout, unreclaimableSweep string
-	if len(spec.Profiles) > 0 {
-		selectedProfile = flags.String("profile", "", "runtime profile")
-	}
-	if spec.RequireQueues {
-		flags.Var(&selectedQueues, "queues", "registered queues to consume (comma-separated or repeatable)")
-		flags.Var(
-			&queueConcurrency,
-			"queue-concurrency",
-			"queue worker budgets as queue=workers entries (comma-separated or repeatable)",
-		)
-		flags.StringVar(&workerGroup, "worker-group", "", "stable worker group label for logs and metrics")
-		flags.StringVar(&shutdownTimeout, "shutdown-timeout", "", "graceful shutdown timeout")
-	}
-	if spec.UnreclaimableSweep {
-		flags.StringVar(
-			&unreclaimableSweep,
-			"unreclaimable-sweep",
-			"",
-			"unreclaimable dispatch sweep: off|shadow|active (default shadow). "+
-				"Setting active asserts that no Celery consumer serves provider "+
-				"units for this deployment",
-		)
-	}
+	bound := registerOptions(flags, spec)
 	if err := flags.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
 		}
+		// An unrecognized flag lands here and stops the process. This is the
+		// half of the contract an environment variable could never offer: a
+		// misspelled variable name is indistinguishable from an unset one and
+		// stays silently inert, which is how OTEL_SERVICE_NAMEi survived in
+		// production.
 		fmt.Fprintf(streams.Stderr, "argument error: %s\n", logging.RedactText(err.Error()))
+		fmt.Fprintf(streams.Stderr, "run %s --help for the full option list\n", spec.Service)
 		return 2
 	}
 	if flags.NArg() != 0 {
 		fmt.Fprintln(streams.Stderr, "argument error: positional arguments are not accepted")
 		return 2
+	}
+	var selectedProfile *string
+	if profile, registered := bound["profile"]; registered {
+		selectedProfile = &profile.raw
 	}
 
 	build := version.Current(spec.Service)
@@ -191,25 +282,24 @@ func Execute(
 		fmt.Fprintf(streams.Stderr, "configuration error: %s\n", logging.RedactText(err.Error()))
 		return 1
 	}
-	cfg, err := config.Load(config.Spec{
+	loadSpec := config.Spec{
 		Service:       spec.Service,
 		Profile:       profile,
 		RequireQueues: spec.RequireQueues,
-		Queues:        append([]string(nil), selectedQueues...),
-		QueueConcurrency: append(
-			[]string(nil), queueConcurrency...,
-		),
-		WorkerGroup:        workerGroup,
-		ShutdownTimeout:    shutdownTimeout,
-		UnreclaimableSweep: unreclaimableSweep,
-		LookupEnv:          lookup,
-	})
+		Overrides:     overridesFrom(bound),
+		LookupEnv:     lookup,
+	}
+	if queues, registered := bound["queues"]; registered && queues.set {
+		loadSpec.Queues = []string{queues.raw}
+	}
+	cfg, err := config.Load(loadSpec)
 	if err != nil {
 		fmt.Fprintf(streams.Stderr, "configuration error: %s\n", logging.RedactText(err.Error()))
 		return 1
 	}
 
 	logger := logging.NewJSON(streams.Stdout, cfg.LogLevel)
+	warnEnvOnlySettings(logger, cfg)
 	tracingComponent := tracing.Init(logger)
 	registry := health.NewRegistry(cfg.HealthCheckTimeout)
 	operatorHTTP, err := health.NewServer(health.ServerOptions{

--- a/internal/platform/shell/shell_test.go
+++ b/internal/platform/shell/shell_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -516,5 +517,316 @@ func TestShellStartsEndpointsAndTerminatesCleanly(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "postgres://") {
 		t.Fatalf("startup logs exposed a DSN: %s", stdout.String())
+	}
+}
+
+// TestUnknownFlagIsRejectedAtStartup is the acceptance test for "a typo'd
+// option fails loudly at startup" (CHAOS-4020). The environment surface this
+// replaces has no equivalent: a misspelled variable name is indistinguishable
+// from an unset one, which is how a typo'd OTEL_SERVICE_NAMEi sat inert in
+// production. The exit status must be the argument-error status, not a
+// configuration or runtime failure, and the process must never reach dependency
+// construction.
+func TestUnknownFlagIsRejectedAtStartup(t *testing.T) {
+	for _, args := range [][]string{
+		{"--queeues=metrics"},
+		{"--otel-service-namei=worker"},
+		{"--concurrency=metrics=1", "--not-a-flag"},
+		{"--worker-group"}, // present but missing its value
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			constructed := false
+			var stdout, stderr bytes.Buffer
+			code := Execute(
+				t.Context(),
+				Spec{
+					Service:       "dev-health-worker",
+					RequireQueues: true,
+					ConfigureDependencies: func(
+						context.Context, config.Config, *health.Registry,
+					) ([]lifecycle.Component, error) {
+						constructed = true
+						return nil, nil
+					},
+				},
+				args,
+				testLookup(nil),
+				IO{Stdout: &stdout, Stderr: &stderr},
+			)
+			if code != 2 {
+				t.Fatalf("exit code = %d, want 2 for an argument error", code)
+			}
+			if constructed {
+				t.Fatal("dependency construction must never run for an unparseable command line")
+			}
+			if !strings.Contains(stderr.String(), "--help") {
+				t.Errorf("the failure must point at --help, got %q", stderr.String())
+			}
+		})
+	}
+}
+
+// TestHelpListsEveryOptionAndExitsCleanly keeps --help the single discovery
+// surface: an operator configuring a worker for the first time must be able to
+// read the whole option set, including the environment fallback of each option
+// and the route vocabulary, without exit status noise.
+func TestHelpListsEveryOptionAndExitsCleanly(t *testing.T) {
+	for _, flag := range []string{"-h", "--help"} {
+		t.Run(flag, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := Execute(
+				t.Context(),
+				Spec{Service: "dev-health-worker", RequireQueues: true},
+				[]string{flag},
+				testLookup(nil),
+				IO{Stdout: &stdout, Stderr: &stderr},
+			)
+			if code != 0 {
+				t.Fatalf("exit code = %d, want 0 for --help", code)
+			}
+			help := stdout.String()
+			for _, fragment := range []string{
+				"-Q, --queues",
+				"-c, --concurrency",
+				"DEV_HEALTH_QUEUE_CONCURRENCY",
+				"PROVIDER ROUTE SWITCHES",
+				"POSTGRES_URI",
+				"environment only",
+			} {
+				if !strings.Contains(help, fragment) {
+					t.Errorf("--help is missing %q", fragment)
+				}
+			}
+		})
+	}
+}
+
+// TestShortAndLongQueueFlagsAreOneSetting proves -q and --queues are aliases of
+// a single value rather than two settings that could disagree, and that the
+// deprecated --queue-concurrency spelling still reaches the same place.
+func TestShortAndLongQueueFlagsAreOneSetting(t *testing.T) {
+	for name, args := range map[string][]string{
+		// -Q is Celery's spelling and the canonical short form here.
+		"celery short":     {"-Q", "metrics,reports", "-c", "metrics=2,reports=1"},
+		"short":            {"-q", "metrics,reports", "-c", "metrics=2,reports=1"},
+		"long":             {"--queues=metrics,reports", "--concurrency=metrics=2,reports=1"},
+		"repeated":         {"-q", "metrics", "-q", "reports", "-c", "metrics=2", "-c", "reports=1"},
+		"deprecated alias": {"--queues=metrics,reports", "--queue-concurrency=metrics=2,reports=1"},
+		"mixed celery":     {"-Q", "metrics", "-q", "reports", "-c", "metrics=2,reports=1"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var observed config.Config
+			var stdout, stderr bytes.Buffer
+			code := Execute(
+				t.Context(),
+				Spec{
+					Service:       "dev-health-worker",
+					RequireQueues: true,
+					ConfigureDependencies: func(
+						_ context.Context, cfg config.Config, _ *health.Registry,
+					) ([]lifecycle.Component, error) {
+						observed = cfg
+						return nil, errors.New("stop before running")
+					},
+				},
+				args,
+				testLookup(nil),
+				IO{Stdout: &stdout, Stderr: &stderr},
+			)
+			if code != 1 {
+				t.Fatalf("exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !slices.Equal(observed.Queues, []string{"metrics", "reports"}) {
+				t.Fatalf("queues = %v", observed.Queues)
+			}
+			if observed.WorkerQueueConcurrency["metrics"] != 2 ||
+				observed.WorkerQueueConcurrency["reports"] != 1 {
+				t.Fatalf("concurrency = %v", observed.WorkerQueueConcurrency)
+			}
+		})
+	}
+}
+
+// TestFlagsBeatEnvironmentThroughTheShell exercises the whole precedence chain
+// end to end, and proves the shadowed environment value is reported rather than
+// fatal -- the property that lets configuration move into `command:` one
+// surface at a time while host .env files still carry the old variables.
+func TestFlagsBeatEnvironmentThroughTheShell(t *testing.T) {
+	var observed config.Config
+	var stdout, stderr bytes.Buffer
+	code := Execute(
+		t.Context(),
+		Spec{
+			Service:       "dev-health-worker",
+			RequireQueues: true,
+			ConfigureDependencies: func(
+				_ context.Context, cfg config.Config, _ *health.Registry,
+			) ([]lifecycle.Component, error) {
+				observed = cfg
+				return nil, errors.New("stop before running")
+			},
+		},
+		[]string{
+			"-q", "metrics",
+			"-c", "metrics=2",
+			"--worker-group=from-flag",
+			"--log-level=warn",
+		},
+		testLookup(map[string]string{
+			"DEV_HEALTH_WORKER_GROUP": "from-environment",
+			"DEV_HEALTH_LOG_LEVEL":    "debug",
+			"DEV_HEALTH_HTTP_ADDR":    "127.0.0.1:9099",
+		}),
+		IO{Stdout: &stdout, Stderr: &stderr},
+	)
+	if code != 1 {
+		t.Fatalf("exit code = %d; stderr=%s", code, stderr.String())
+	}
+	if observed.WorkerGroup != "from-flag" {
+		t.Fatalf("worker group = %q, want the flag value", observed.WorkerGroup)
+	}
+	if observed.LogLevel != slog.LevelWarn {
+		t.Fatalf("log level = %s, want the flag value", observed.LogLevel)
+	}
+	// The setting with no flag still resolves from the environment.
+	if observed.HTTPAddress != "127.0.0.1:9099" {
+		t.Fatalf("http address = %q, want the environment fallback", observed.HTTPAddress)
+	}
+	// ...and is named in a startup warning so it is not silently invisible.
+	if !slices.Equal(observed.EnvOnlySettings, []string{"http-addr"}) {
+		t.Fatalf("EnvOnlySettings = %v, want only http-addr", observed.EnvOnlySettings)
+	}
+	if !strings.Contains(stdout.String(), "configuration supplied through environment variables") {
+		t.Error("an environment-configured setting must produce a startup warning")
+	}
+}
+
+// TestCredentialsAreNotAcceptedAsFlags keeps DSNs off the command line at the
+// parse layer, not merely by convention: a --postgres-uri flag would place a
+// credential in `ps` output and in `docker compose config`.
+func TestCredentialsAreNotAcceptedAsFlags(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Execute(
+		t.Context(),
+		Spec{Service: "dev-health-worker", RequireQueues: true},
+		[]string{"--postgres-uri=postgres://operator:hunter2-pw@db.internal/devhealth"},
+		testLookup(nil),
+		IO{Stdout: &stdout, Stderr: &stderr},
+	)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want a rejected argument", code)
+	}
+	// The refusal names the flag, never the value behind it: a rejected
+	// credential must not be copied into the process log by the rejection.
+	if strings.Contains(stderr.String()+stdout.String(), "hunter2-pw") {
+		t.Error("the rejection must not echo the credential it refused")
+	}
+	if !strings.Contains(stderr.String(), "postgres-uri") {
+		t.Errorf("the rejection must name the offending flag, got %q", stderr.String())
+	}
+}
+
+// TestCeleryLogLevelAliasIsAcceptedAndWins pins the other spelling the Python
+// Celery worker CLI uses. The Go worker mirrors that CLI, so an operator moving
+// between the two fleets should not have to remember which one hyphenates.
+func TestCeleryLogLevelAliasIsAcceptedAndWins(t *testing.T) {
+	var observed config.Config
+	var stdout, stderr bytes.Buffer
+	code := Execute(
+		t.Context(),
+		Spec{
+			Service:       "dev-health-worker",
+			RequireQueues: true,
+			ConfigureDependencies: func(
+				_ context.Context, cfg config.Config, _ *health.Registry,
+			) ([]lifecycle.Component, error) {
+				observed = cfg
+				return nil, errors.New("stop before running")
+			},
+		},
+		[]string{"-Q", "metrics", "-c", "metrics=1", "--loglevel=warn"},
+		testLookup(map[string]string{"DEV_HEALTH_LOG_LEVEL": "debug"}),
+		IO{Stdout: &stdout, Stderr: &stderr},
+	)
+	if code != 1 {
+		t.Fatalf("exit code = %d; stderr=%s", code, stderr.String())
+	}
+	if observed.LogLevel != slog.LevelWarn {
+		t.Fatalf("log level = %s, want the --loglevel flag value", observed.LogLevel)
+	}
+}
+
+// TestRoutesFlagIsGone is a deliberate negative: provider route enablement is
+// not a CLI surface. A worker executes the queues it subscribes to, and the
+// forty WORKER_*_ENABLED switches survive only as the producer/executor
+// agreement. Re-adding a --routes flag should fail here.
+func TestRoutesFlagIsGone(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Execute(
+		t.Context(),
+		Spec{Service: "dev-health-worker", RequireQueues: true},
+		[]string{"-Q", "metrics", "-c", "metrics=1", "--routes=github/prs"},
+		testLookup(nil),
+		IO{Stdout: &stdout, Stderr: &stderr},
+	)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 for an undefined flag", code)
+	}
+}
+
+// TestBlankFlagDoesNotShadowTheEnvironment is the regression guard for a defect
+// an adversarial review found that my own blank-value test could not: that test
+// asserted a blank flag resolves to the DEFAULT, with no environment value
+// present. Both "blank is ignored" and "blank overrides with nothing" satisfy
+// that, so it passed while the second was true.
+//
+// The distinguishing case needs a NON-BLANK environment value to shadow. On
+// main a blank argument was trimmed and fell through to the environment; an
+// empty override that won instead would silently drop a deployment's shutdown
+// budget to the 30s package default and flip ShutdownTimeoutExplicit, which
+// feeds the drain-budget branch in cmd/dev-health-worker.
+func TestBlankFlagDoesNotShadowTheEnvironment(t *testing.T) {
+	var observed config.Config
+	var stdout, stderr bytes.Buffer
+	code := Execute(
+		t.Context(),
+		Spec{
+			Service:       "dev-health-worker",
+			RequireQueues: true,
+			ConfigureDependencies: func(
+				_ context.Context, cfg config.Config, _ *health.Registry,
+			) ([]lifecycle.Component, error) {
+				observed = cfg
+				return nil, errors.New("stop before running")
+			},
+		},
+		[]string{
+			"-Q", "heartbeat",
+			"-c", "heartbeat=1",
+			"--shutdown-timeout=",
+			"--worker-group=",
+			"--log-level=",
+		},
+		testLookup(map[string]string{
+			"DEV_HEALTH_SHUTDOWN_TIMEOUT": "7260s",
+			"DEV_HEALTH_WORKER_GROUP":     "ops",
+			"DEV_HEALTH_LOG_LEVEL":        "warn",
+		}),
+		IO{Stdout: &stdout, Stderr: &stderr},
+	)
+	if code != 1 {
+		t.Fatalf("exit code = %d; stderr=%s", code, stderr.String())
+	}
+	if observed.ShutdownTimeout != 7260*time.Second {
+		t.Fatalf("shutdown timeout = %s, want the environment's 7260s", observed.ShutdownTimeout)
+	}
+	if !observed.ShutdownTimeoutExplicit {
+		t.Error("an environment-supplied timeout must still count as an operator choice")
+	}
+	if observed.WorkerGroup != "ops" {
+		t.Fatalf("worker group = %q, want the environment's ops", observed.WorkerGroup)
+	}
+	if observed.LogLevel != slog.LevelWarn {
+		t.Fatalf("log level = %s, want the environment's warn", observed.LogLevel)
 	}
 }

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -188,7 +188,7 @@ _PROD_COMPOSE = _REPO_ROOT / "deploy" / "docker-compose" / "compose.production.y
 _LEGACY_COMPOSE = _REPO_ROOT / "compose.yml"
 _SWARM_STACK = _REPO_ROOT / "deploy" / "docker-swarm" / "stack.yml"
 _GO_WORKER_OVERLAY = _REPO_ROOT / "deploy" / "go-workers" / "compose-go-workers.yml"
-_GO_CONFIG = _REPO_ROOT / "internal" / "platform" / "config" / "config.go"
+_GO_CONFIG_PACKAGE = _REPO_ROOT / "internal" / "platform" / "config"
 _K8S_DIR = _REPO_ROOT / "deploy" / "kubernetes"
 _HELM_DIR = _REPO_ROOT / "deploy" / "helm" / "dev-health"
 
@@ -1362,9 +1362,18 @@ def test_local_postgres_image_pinned_and_pgdata_is_subdirectory() -> None:
 
 def test_provider_route_switch_inventory_matches_go_config() -> None:
     """The packaging census must move with the typed Go configuration surface."""
+    # Scan the whole platform config package rather than one file in it.
+    # CHAOS-4020 moved the route switches out of config.go into their own
+    # registry, and a census pinned to a single filename would have gone quietly
+    # empty instead of failing -- the same shape of silent drift this census
+    # exists to catch.
     configured = frozenset(
-        re.findall(r'"(WORKER_[A-Z0-9_]+_ENABLED)"', _GO_CONFIG.read_text())
+        name
+        for source in sorted(_GO_CONFIG_PACKAGE.glob("*.go"))
+        if not source.name.endswith("_test.go")
+        for name in re.findall(r'"(WORKER_[A-Z0-9_]+_ENABLED)"', source.read_text())
     )
+    assert configured, "the route-switch census scanned no Go source at all"
     assert configured == _PROVIDER_ROUTE_SWITCH_NAMES
 
 

--- a/tests/workers/test_go_worker_cli_contract.py
+++ b/tests/workers/test_go_worker_cli_contract.py
@@ -1,0 +1,430 @@
+"""CHAOS-4020 acceptance: the Go workers are configured by flags, not by ~85
+unfindable environment variables.
+
+The inventory that opened the ticket found 85 operator-facing variables across
+``cmd/dev-health-worker``, ``-reconciler``, ``-scheduler``, and the stream
+runner: 79 in the platform config package (40 of them provider route switches),
+5 read straight from the process environment by the tracing package, and
+``DEV_HEALTH_PROFILE``.
+
+Three properties are pinned here, one per acceptance criterion:
+
+* every setting is reachable from ``--help`` (discovery),
+* a misspelled option cannot reach a deploy manifest unnoticed (loud failure),
+* a standard deployment configures a handful of credentials (env count).
+
+These assertions read the checked-in Go registries and the deploy manifests, so
+they fail on the surface an operator actually touches rather than on a mirrored
+list maintained by hand.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CONFIG_PACKAGE = _REPO_ROOT / "internal" / "platform" / "config"
+_OPTIONS_SOURCE = _CONFIG_PACKAGE / "options.go"
+_ROUTES_SOURCE = _CONFIG_PACKAGE / "routes.go"
+
+_GO_COMPOSE = _REPO_ROOT / "deploy" / "docker-compose" / "compose.go-workers.yml"
+_GO_SWARM = _REPO_ROOT / "deploy" / "docker-swarm" / "stack.go-workers.yml"
+_GO_KUBERNETES = _REPO_ROOT / "deploy" / "kubernetes" / "go-workers.yaml"
+_HELM_WORKERS = (
+    _REPO_ROOT / "deploy" / "helm" / "dev-health" / "templates" / "go-workers.yaml"
+)
+
+# Credentials stay in the environment on purpose. A DSN or token passed as a
+# process argument is readable through `ps`, `docker inspect`, and the very
+# `docker compose config` output this ticket asks operators to read, so the
+# registry declares them Secret and offers no flag for them.
+_CREDENTIALS = frozenset(
+    {
+        "POSTGRES_URI",
+        "WORKER_DATABASE_URI",
+        "COORDINATOR_DATABASE_URI",
+        "CLICKHOUSE_URI",
+        "VALKEY_URI",
+        "SETTINGS_ENCRYPTION_KEY",
+        "SETTINGS_ENCRYPTION_SALT",
+        "PAGER_DUTY_CLIENT_ID",
+        "PAGER_DUTY_SECRET",
+        "WORKER_OPERATIONAL_BRIDGE_TOKEN",
+    }
+)
+
+# AUTO_RUN_MIGRATIONS is read by the Python runtime image's entrypoint, not by
+# any Go binary, so it is not part of the worker configuration surface.
+_NON_WORKER_ENV = frozenset({"AUTO_RUN_MIGRATIONS"})
+
+
+def _go_flag_names() -> frozenset[str]:
+    """Every long flag the option registry offers, including aliases."""
+    source = _OPTIONS_SOURCE.read_text(encoding="utf-8")
+    names = set(re.findall(r'\bFlag:\s*"([a-z0-9-]+)"', source))
+    for block in re.findall(r"Aliases:\s*\[\]string\{([^}]*)\}", source):
+        names.update(re.findall(r'"([a-z0-9-]+)"', block))
+    assert names, "no flags parsed from the option registry"
+    return frozenset(names)
+
+
+def _go_secret_env() -> frozenset[str]:
+    source = _OPTIONS_SOURCE.read_text(encoding="utf-8")
+    return frozenset(re.findall(r'\{Env:\s*"([A-Z0-9_]+)",\s*Secret:\s*true', source))
+
+
+def _flags_of(items: object) -> set[str]:
+    """Long flag names in one container's command/args list."""
+    if not isinstance(items, list):
+        return set()
+    return {
+        match.group(1)
+        for match in (re.match(r"--([a-z][a-z0-9-]*)=", str(item)) for item in items)
+        if match
+    }
+
+
+def _compose_manifest_flags(path: Path) -> set[str]:
+    """Flags the Go worker services of a Compose/Swarm file actually pass.
+
+    Scanning the file as raw text would also sweep up the psql provisioning
+    entrypoint's --host/--dbname, which belong to a different program.
+    """
+    flags: set[str] = set()
+    for service in _compose_worker_services(path).values():
+        flags |= _flags_of(service.get("command"))
+    return flags
+
+
+def _kubernetes_manifest_flags(path: Path) -> set[str]:
+    flags: set[str] = set()
+    for document in yaml.safe_load_all(path.read_text(encoding="utf-8")):
+        if not document or document.get("kind") != "Deployment":
+            continue
+        for container in document["spec"]["template"]["spec"]["containers"]:
+            flags |= _flags_of(container.get("args"))
+    return flags
+
+
+def _helm_manifest_flags(path: Path) -> set[str]:
+    """Flags a Helm template emits, read from the template source.
+
+    The template is not YAML until it is rendered, so this reads the literal
+    flag names out of the quoted list items and printf formats that produce
+    them.
+    """
+    text = path.read_text(encoding="utf-8")
+    return set(re.findall(r'-\s*(?:\{\{[^"]*)?"--([a-z][a-z0-9-]*)=', text))
+
+
+def _compose_worker_services(path: Path) -> dict[str, dict]:
+    services = yaml.safe_load(path.read_text(encoding="utf-8"))["services"]
+    return {
+        name: service
+        for name, service in services.items()
+        if isinstance(service.get("labels"), dict)
+        and "dev-health.io/worker-group" in service["labels"]
+    }
+
+
+def test_registry_declares_the_credentials_that_stay_in_the_environment() -> None:
+    """The documented handful is exactly the credential set.
+
+    If a credential loses its Secret marker it gains a flag, and the value lands
+    in `ps` output; if a non-credential gains one it becomes unreachable from
+    --help. Either direction fails here.
+    """
+    assert _go_secret_env() == _CREDENTIALS
+
+
+@pytest.mark.parametrize(
+    ("path", "extract"),
+    [
+        (_GO_COMPOSE, _compose_manifest_flags),
+        (_GO_SWARM, _compose_manifest_flags),
+        (_GO_KUBERNETES, _kubernetes_manifest_flags),
+        (_HELM_WORKERS, _helm_manifest_flags),
+    ],
+    ids=["compose", "swarm", "kubernetes", "helm"],
+)
+def test_deploy_manifests_only_pass_flags_the_binaries_accept(
+    path: Path, extract
+) -> None:
+    """A misspelled option in a manifest fails here, and again at startup.
+
+    This is the half of the contract the environment surface could never offer.
+    A misspelled variable name is indistinguishable from an unset one and stays
+    silently inert -- exactly how a typo'd ``OTEL_SERVICE_NAMEi`` survived in
+    production. A misspelled flag is rejected by ``flag.ContinueOnError`` at
+    startup; this test moves that failure earlier still, to review time.
+    """
+    passed = extract(path)
+    assert passed, f"{path.name} passes no flags at all"
+    unknown = passed - _go_flag_names()
+    assert not unknown, (
+        f"{path.name} passes flags no Go worker binary declares: {sorted(unknown)}. "
+        "Add them to internal/platform/config/options.go or fix the spelling."
+    )
+
+
+@pytest.mark.parametrize("path", [_GO_COMPOSE, _GO_SWARM], ids=["compose", "swarm"])
+def test_compose_surfaces_keep_only_credentials_in_the_environment(
+    path: Path,
+) -> None:
+    """`docker compose config` shows the deployed configuration.
+
+    Before CHAOS-4020 a worker's configuration was reconstructed from a shared
+    env anchor plus a host .env file. Every non-credential setting now renders
+    in ``command:``, so what a container runs is readable in one place.
+    """
+    services = _compose_worker_services(path)
+    assert services, f"{path.name} declares no Go worker services"
+    for name, service in services.items():
+        environment = set(service.get("environment") or {})
+        leaked = environment - _CREDENTIALS - _NON_WORKER_ENV
+        assert not leaked, (
+            f"{path.name}:{name} still configures {sorted(leaked)} through the "
+            "environment; pass them as flags in command: instead"
+        )
+        command = service.get("command") or []
+        assert command, f"{path.name}:{name} passes no flags at all"
+        assert all(str(item).startswith("--") for item in command), (
+            f"{path.name}:{name} mixes positional arguments into command:"
+        )
+
+
+def test_kubernetes_workers_keep_only_credentials_in_inline_env() -> None:
+    documents = [
+        document
+        for document in yaml.safe_load_all(_GO_KUBERNETES.read_text(encoding="utf-8"))
+        if document and document.get("kind") == "Deployment"
+    ]
+    assert documents, "no Go worker Deployments found"
+    for document in documents:
+        container = document["spec"]["template"]["spec"]["containers"][0]
+        inline = {item["name"] for item in container.get("env") or []}
+        leaked = inline - _CREDENTIALS - _NON_WORKER_ENV
+        assert not leaked, (
+            f"{document['metadata']['name']} still configures {sorted(leaked)} "
+            "through inline env; pass them as args instead"
+        )
+        assert container.get("args"), (
+            f"{document['metadata']['name']} passes no flags at all"
+        )
+
+
+def test_every_worker_deployment_states_its_own_drain_budget() -> None:
+    """The drain budget is the setting most likely to be silently inherited.
+
+    It must cover the longest selected job timeout, so a group that does not
+    state it is relying on a 30s package default that no real queue selection
+    can satisfy.
+    """
+    for path in (_GO_COMPOSE, _GO_SWARM):
+        for name, service in _compose_worker_services(path).items():
+            command = " ".join(str(item) for item in service.get("command") or [])
+            assert "--shutdown-timeout=" in command, (
+                f"{path.name}:{name} does not state a drain budget"
+            )
+
+
+def _celery_queue_names() -> frozenset[str]:
+    """The Celery app's declared queue set, read from the producer itself.
+
+    Generated from ``workers.config.task_queues`` rather than hand-authored, so
+    a queue added on the Python side cannot drift away from this comparison
+    silently.
+    """
+    from dev_health_ops.workers.config import task_queues
+
+    return frozenset(task_queues)
+
+
+def _go_queue_names() -> frozenset[str]:
+    """The queues the Go River fleet actually serves, per the deployment manifest."""
+    import json
+
+    manifest = json.loads(
+        (_REPO_ROOT / "deploy" / "go-workers" / "deployment.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    return frozenset(
+        queue
+        for process in manifest["processes"]
+        for queue in process.get("queues", [])
+    )
+
+
+def test_go_queue_names_that_exist_in_celery_agree_byte_for_byte() -> None:
+    """Where the two runtimes name the same queue, they must spell it the same.
+
+    CHAOS-4020 mirrors the Celery worker CLI: `-Q/--queues` takes queue names,
+    with Celery's meaning. The two fleets do not serve identical queue sets --
+    the Go River topology has queues Celery never had, and Celery has queues no
+    Go handler implements -- so this pins the part that must not drift: a queue
+    both runtimes know is spelled identically, and the divergence is explicit
+    rather than accidental.
+
+    The divergence lists below are the migration's open question, tracked on
+    CHAOS-4020. A name moving between the two sets should fail here and be a
+    deliberate edit, not a surprise.
+    """
+    celery = _celery_queue_names()
+    go = _go_queue_names()
+
+    shared = celery & go
+    assert shared == {"metrics", "reports", "sync", "webhooks"}, (
+        f"the shared queue vocabulary changed: {sorted(shared)}"
+    )
+
+    # Queues the Go fleet serves that the Celery app never declared.
+    assert go - celery == {
+        "coverage",
+        "heartbeat",
+        "investment",
+        "retention",
+        "sync_provider",
+        "workgraph",
+    }, f"Go-only queues changed: {sorted(go - celery)}"
+
+    # Celery queues no Go worker implements a handler for. A Go worker must not
+    # accept these: startup validation requires the selected queue set to equal
+    # the CONSTRUCTED handler set, so selecting one would fail readiness.
+    assert celery - go == {
+        "backfill",
+        "default",
+        "external-ingest",
+        "ingest",
+        "monitoring",
+        "scheduler",
+        "sync.github",
+        "sync.github.heavy",
+        "sync.github.light",
+        "sync.github.medium",
+        "sync.gitlab",
+        "sync.gitlab.heavy",
+        "sync.gitlab.light",
+        "sync.gitlab.medium",
+        "sync.jira",
+        "sync.jira.medium",
+        "sync.launchdarkly",
+        "sync.linear",
+        "sync.linear.medium",
+    }, f"Celery-only queues changed: {sorted(celery - go)}"
+
+
+def test_every_queue_a_manifest_selects_is_one_the_go_fleet_serves() -> None:
+    """`-Q` names real queues; a manifest cannot select one nothing serves."""
+    go = _go_queue_names()
+    for path, extract in (
+        (_GO_COMPOSE, _compose_worker_services),
+        (_GO_SWARM, _compose_worker_services),
+    ):
+        for name, service in extract(path).items():
+            for item in service.get("command") or []:
+                if not str(item).startswith("--queues="):
+                    continue
+                selected = set(str(item).split("=", 1)[1].split(","))
+                unknown = selected - go
+                assert not unknown, (
+                    f"{path.name}:{name} selects queues the Go fleet does not "
+                    f"serve: {sorted(unknown)}"
+                )
+
+
+# Flags whose value would otherwise come from the shared ConfigMap. Because
+# resolution is flag > env, hard-coding one of these into a Deployment's args
+# silently disables the ConfigMap as an operator tuning surface.
+_CONFIGMAP_BACKED_FLAGS = {
+    "--river-schema": "RIVER_DATABASE_SCHEMA",
+    "--domain-database-role": "RIVER_DOMAIN_DATABASE_ROLE",
+    "--queue-database-role": "RIVER_QUEUE_DATABASE_ROLE",
+    "--operational-bridge-url": "WORKER_OPERATIONAL_BRIDGE_URL",
+    "--operational-bridge-allow-insecure": "WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE",
+    "--pagerduty-webhook-transport": "PAGERDUTY_WEBHOOK_TRANSPORT",
+}
+
+
+def test_kubernetes_args_never_shadow_the_configmap() -> None:
+    """A Deployment must not hard-code a setting the ConfigMap owns.
+
+    CHAOS-4020 made flags win over the environment. A Deployment that both
+    imports ``dev-health-config`` via envFrom AND passes the same setting as an
+    argument therefore renders the ConfigMap inert for that key: editing it
+    changes nothing.
+
+    ``PAGERDUTY_WEBHOOK_TRANSPORT`` is the sharp case. Both runtimes read it,
+    and the contract is that exactly one owns the webhook stream. If a
+    ConfigMap edit flipped the Python API to ``river`` while a hard-coded Go
+    argument kept ``celery``, the stream would have two owners reconciling and
+    deleting each other's entries.
+    """
+    configmap = yaml.safe_load(
+        (_REPO_ROOT / "deploy" / "kubernetes" / "configmap.yaml").read_text(
+            encoding="utf-8"
+        )
+    )["data"]
+
+    for document in yaml.safe_load_all(_GO_KUBERNETES.read_text(encoding="utf-8")):
+        if not document or document.get("kind") != "Deployment":
+            continue
+        container = document["spec"]["template"]["spec"]["containers"][0]
+        imports_configmap = any(
+            source.get("configMapRef") for source in container.get("envFrom") or []
+        )
+        if not imports_configmap:
+            continue
+        passed = _flags_of(container.get("args"))
+        for flag, variable in _CONFIGMAP_BACKED_FLAGS.items():
+            if variable not in configmap:
+                continue
+            assert flag.removeprefix("--") not in passed, (
+                f"{document['metadata']['name']} hard-codes {flag}, which makes "
+                f"ConfigMap key {variable} inert for this Deployment"
+            )
+
+
+def test_provider_route_switches_have_no_flag_surface() -> None:
+    """Route enablement must stay off the CLI.
+
+    A worker executes the queues it subscribes to (``-Q``); a parallel
+    forty-switch enablement surface does not scale and is the thing CHAOS-4020
+    designed away. The forty ``WORKER_*_ENABLED`` variables survive only as the
+    agreement between the Python planner, which reads the same names to decide
+    what to *plan*, and the Go executor.
+
+    Nothing else pins that. If a ``Flag``/``Short``/``Aliases`` field ever
+    appears on a ``Route``, forty options quietly return to ``--help`` and the
+    decision reverses without anyone choosing it — so the registry is asserted
+    to declare data and targets only.
+    """
+    source = _ROUTES_SOURCE.read_text(encoding="utf-8")
+
+    # Matched as bare identifiers, not "Flag:", so this catches BOTH a struct
+    # field declaration on Route and a literal assignment in the registry. An
+    # earlier version of this guard required the colon and silently ignored
+    # `Flag string` added to the type -- it passed a mutation that should have
+    # failed it.
+    offending = sorted(set(re.findall(r"\b(Flag|Short|Aliases)\b", source)))
+    assert not offending, (
+        f"routes.go declares CLI field(s) {offending}; provider route switches "
+        "are environment-only and must not gain a flag surface"
+    )
+    assert "--routes" not in source, "routes.go must not reintroduce a --routes flag"
+
+    # The registry is still the complete deprecation map: one entry per switch,
+    # each wired to a Config field.
+    entries = re.findall(
+        r'\{Env: "(WORKER_[A-Z0-9_]+_ENABLED)", target: func\(c \*Config\) \*bool',
+        source,
+    )
+    assert len(entries) == 40, (
+        f"routes.go declares {len(entries)} route switches, want the 40 the "
+        "inventory found"
+    )
+    assert len(set(entries)) == len(entries), "duplicate route switch in routes.go"

--- a/tests/workers/test_go_worker_deployment_contract.py
+++ b/tests/workers/test_go_worker_deployment_contract.py
@@ -123,6 +123,18 @@ def _process_arguments(container: dict) -> dict[str, str]:
     return arguments
 
 
+def _optional_process_arguments(container: dict) -> dict[str, str]:
+    """Flags of a container whose command may not be a flag list at all.
+
+    go-contractcheck runs a subcommand rather than a configured worker, so a
+    selector that scans every service in a file cannot assume flag form.
+    """
+    raw = container.get("command") or container.get("args") or []
+    if not isinstance(raw, list) or not all(str(item).startswith("--") for item in raw):
+        return {}
+    return _process_arguments(container)
+
+
 def _load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -185,6 +197,17 @@ def _pagerduty_required_env() -> set[str]:
     return _bridge_secret_env() | _PAGERDUTY_CONFIG_ENV
 
 
+def _flag_variable_default(value: object, variable: str) -> str:
+    """A flag value that stays overridable through a Compose interpolation.
+
+    CHAOS-4020 moved worker configuration out of ``environment:`` and into
+    ``command:`` so ``docker compose config`` renders the deployed configuration
+    in one place. The operator-facing override keeps the same variable name and
+    the same default; only the surface it lands on changed.
+    """
+    return _compose_variable_default(value, variable)
+
+
 def _compose_variable_default(value: object, variable: str) -> str:
     match = re.fullmatch(rf"\$\{{{re.escape(variable)}:-(.*)\}}", str(value), re.DOTALL)
     assert match is not None, f"{variable} must stay overridable with a default"
@@ -195,7 +218,7 @@ def _compose_pagerduty_services(path: Path) -> dict[str, dict]:
     return {
         name: service
         for name, service in (_load_yaml(path).get("services") or {}).items()
-        if (service.get("environment") or {}).get("DEV_HEALTH_PROFILE")
+        if _optional_process_arguments(service).get("--profile")
         == _PAGERDUTY_RUNTIME_PROFILE
     }
 
@@ -232,12 +255,16 @@ def _kubernetes_container_env(container: dict) -> set[str]:
 
 
 def _kubernetes_container_profile(container: dict) -> str | None:
-    """The DEV_HEALTH_PROFILE this container actually runs with.
+    """The runtime profile this container actually runs with.
 
-    Inline env wins; otherwise the value is inherited from a referenced
-    ConfigMap. A label is metadata and does not reach the process, so it can
-    never stand in for this.
+    CHAOS-4020 made --profile the canonical surface, so the flag is checked
+    first; an inline env value is the 12-factor fallback beneath it, and a
+    referenced ConfigMap is beneath that. A label is metadata and does not reach
+    the process, so it can never stand in for any of these.
     """
+    flag = _optional_process_arguments(container).get("--profile")
+    if flag is not None:
+        return flag
     for item in container.get("env") or []:
         if item["name"] == "DEV_HEALTH_PROFILE":
             return item.get("value")
@@ -411,8 +438,8 @@ def test_go_deployment_surfaces_are_additive_default_off_and_group_complete() ->
         assert "no-new-privileges:true" in service["security_opt"]
         assert service["environment"]["AUTO_RUN_MIGRATIONS"] == "false"
         assert (
-            _compose_variable_default(
-                service["environment"]["PGBOUNCER_TRANSACTION_MODE"],
+            _flag_variable_default(
+                _process_arguments(service)["--domain-transaction-pooler"],
                 "PGBOUNCER_TRANSACTION_MODE",
             )
             == "true"
@@ -431,8 +458,8 @@ def test_go_deployment_surfaces_are_additive_default_off_and_group_complete() ->
         assert service["user"] == "65532:65532"
         assert service["environment"]["AUTO_RUN_MIGRATIONS"] == "false"
         assert (
-            _compose_variable_default(
-                service["environment"]["PGBOUNCER_TRANSACTION_MODE"],
+            _flag_variable_default(
+                _process_arguments(service)["--domain-transaction-pooler"],
                 "PGBOUNCER_TRANSACTION_MODE",
             )
             == "true"
@@ -566,8 +593,12 @@ def test_river_worker_renderers_select_manifest_queues_without_profiles() -> Non
     }
     for group, (service_name, runtime_profile) in stream_runtime_profiles.items():
         for services in (compose, swarm):
-            environment = services[service_name]["environment"]
-            assert environment["DEV_HEALTH_PROFILE"] == runtime_profile
+            service = services[service_name]
+            # CHAOS-4020: the runtime profile is a flag, so it is visible in
+            # the rendered `command:` rather than in a merged environment map.
+            assert _process_arguments(service)["--profile"] == runtime_profile
+            environment = service["environment"]
+            assert "DEV_HEALTH_PROFILE" not in environment
             assert "DEV_HEALTH_QUEUE_CONCURRENCY" not in environment
             assert "DEV_HEALTH_WORKER_GROUP" not in environment
         deployment = deployments[f"dev-health-{service_name}"]
@@ -662,20 +693,22 @@ def test_group_replica_and_drain_contract_matches_every_renderer() -> None:
                 == f"{grace}s"
             )
         else:
+            # CHAOS-4020: coordinator and stream binaries carry the drain budget
+            # as --shutdown-timeout too, so every renderer states it the same
+            # way and `docker compose config` shows it without a merged
+            # environment map.
             assert (
-                compose[service_name]["environment"]["DEV_HEALTH_SHUTDOWN_TIMEOUT"]
+                _process_arguments(compose[service_name])["--shutdown-timeout"]
                 == f"{grace}s"
             )
             assert (
-                swarm[service_name]["environment"]["DEV_HEALTH_SHUTDOWN_TIMEOUT"]
+                _process_arguments(swarm[service_name])["--shutdown-timeout"]
                 == f"{grace}s"
             )
-            shutdown = next(
-                item
-                for item in pod_spec["containers"][0]["env"]
-                if item["name"] == "DEV_HEALTH_SHUTDOWN_TIMEOUT"
+            assert (
+                _process_arguments(pod_spec["containers"][0])["--shutdown-timeout"]
+                == f"{grace}s"
             )
-            assert shutdown["value"] == f"{grace}s"
         assert helm[profile]["replicas"] == desired
         assert helm[profile]["terminationGracePeriodSeconds"] == grace
         if contract["runtime"] == "river":
@@ -1171,25 +1204,40 @@ def test_compose_surfaces_render_complete_pagerduty_bridge_env(
     services = _compose_pagerduty_services(path)
     assert bool(services) == required_declaration
 
-    required = _pagerduty_required_env()
+    # CHAOS-4020: every one of these settings except the bearer token moved
+    # from `environment:` to `command:`. The completeness requirement is
+    # unchanged -- the runner still cannot open readiness without all of them --
+    # only the surface each one is rendered on.
+    flag_for = {
+        "WORKER_OPERATIONAL_BRIDGE_URL": "--operational-bridge-url",
+        "WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE": (
+            "--operational-bridge-allow-insecure"
+        ),
+        "PAGERDUTY_WEBHOOK_TRANSPORT": "--pagerduty-webhook-transport",
+    }
     for name, service in services.items():
         environment = service["environment"]
-        missing = required - set(environment)
+        arguments = _process_arguments(service)
+        missing = {
+            variable
+            for variable in _pagerduty_required_env()
+            if variable not in environment and flag_for.get(variable) not in arguments
+        }
         assert not missing, f"{path.name}:{name} drops {sorted(missing)}"
         _assert_insecure_optin_covers_endpoint(
-            _compose_variable_default(
-                environment["WORKER_OPERATIONAL_BRIDGE_URL"],
+            _flag_variable_default(
+                arguments["--operational-bridge-url"],
                 "WORKER_OPERATIONAL_BRIDGE_URL",
             ),
-            _compose_variable_default(
-                environment["WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE"],
+            _flag_variable_default(
+                arguments["--operational-bridge-allow-insecure"],
                 "WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE",
             ),
             f"{path.name}:{name}",
         )
         assert (
-            _compose_variable_default(
-                environment["PAGERDUTY_WEBHOOK_TRANSPORT"],
+            _flag_variable_default(
+                arguments["--pagerduty-webhook-transport"],
                 "PAGERDUTY_WEBHOOK_TRANSPORT",
             )
             == _DEFAULT_WEBHOOK_TRANSPORT
@@ -1247,9 +1295,9 @@ def test_helm_pagerduty_profile_resolves_complete_bridge_env() -> None:
         encoding="utf-8"
     )
     assert (
-        "{name: DEV_HEALTH_PROFILE, value: {{ $group.runtimeProfile | quote }}}"
-        in workers_template
-    ), "the chart must render DEV_HEALTH_PROFILE from $group.runtimeProfile"
+        '- {{ printf "--profile=%s" . | quote }}' in workers_template
+        and "{{- with $group.runtimeProfile }}" in workers_template
+    ), "the chart must render --profile from $group.runtimeProfile"
 
     # Every Go worker group inherits the shared ConfigMap and Secret, so the chart's
     # value surface is what decides whether the runner is wired.

--- a/tests/workers/test_helm_go_pgbouncer.py
+++ b/tests/workers/test_helm_go_pgbouncer.py
@@ -226,8 +226,14 @@ def test_go_pgbouncer_render_scopes_role_dsns_and_preserves_direct_migrations() 
             environment["WORKER_DATABASE_URI"]["valueFrom"]["secretKeyRef"]["key"]
             == "WORKER_DATABASE_URI"
         )
-        assert environment["WORKER_DATABASE_MODE"]["value"] == "session"
-        assert environment["PGBOUNCER_TRANSACTION_MODE"]["value"] == "true"
+        # CHAOS-4020: the pool semantics are flags, not environment. Only the
+        # DSNs themselves stay in env, where a secretKeyRef can project them
+        # without exposing them in the pod's command line.
+        arguments = container["args"]
+        assert "--queue-database-mode=session" in arguments
+        assert "--domain-transaction-pooler=true" in arguments
+        assert "WORKER_DATABASE_MODE" not in environment
+        assert "PGBOUNCER_TRANSACTION_MODE" not in environment
         assert "MIGRATION_DATABASE_URI" not in environment
         assert "MIGRATION_DATABASE_URI_FILE" not in environment
         if profile in _COORDINATOR_GROUPS:
@@ -237,7 +243,8 @@ def test_go_pgbouncer_render_scopes_role_dsns_and_preserves_direct_migrations() 
                 ]
                 == "COORDINATOR_DATABASE_URI"
             )
-            assert environment["COORDINATOR_DATABASE_MODE"]["value"] == "session"
+            assert "--coordinator-database-mode=session" in arguments
+            assert "COORDINATOR_DATABASE_MODE" not in environment
         else:
             assert "COORDINATOR_DATABASE_URI" not in environment
             assert "COORDINATOR_DATABASE_MODE" not in environment
@@ -315,12 +322,19 @@ def test_helm_river_workers_select_manifest_queues_and_queue_metrics() -> None:
         assert "DEV_HEALTH_QUEUES" not in environment
         assert "DEV_HEALTH_QUEUE_CONCURRENCY" not in environment
         assert "DEV_HEALTH_WORKER_GROUP" not in environment
-        assert container["args"] == [
+        # The queue topology leads the argument list; CHAOS-4020 appends the
+        # rest of the worker's configuration after it, so this pins the prefix
+        # and the settings it must carry rather than the exact whole list.
+        assert container["args"][:4] == [
             f"--queues={','.join(process['queues'])}",
             f"--queue-concurrency={_queue_concurrency(process)}",
             f"--worker-group={group}",
             f"--shutdown-timeout={process['shutdown_grace_seconds']}s",
         ]
+        assert "--http-addr=:8080" in container["args"]
+        assert not any(
+            argument.startswith("--profile=") for argument in container["args"]
+        ), f"{group} is a queue worker and must not run a runtime profile"
 
         scaler = next(
             doc


### PR DESCRIPTION
## Summary

The Go workers were configured by an environment surface that could not be discovered and could not fail loudly. This gives them a real CLI, mirroring the Python Celery worker: **`-Q/--queues`**, **`-c/--concurrency`**, purpose-named flags for the remaining worker knobs, **`--help` as the single discovery surface**, a **hard error on unknown flags**, and env retained as a 12-factor fallback (**flag > env > default**). Compose, Swarm, Kubernetes, and Helm carry that configuration in `command:`/`args:`, so `docker compose config` and `kubectl describe pod` show what a container actually runs.

Closes CHAOS-4020.

## Inventory (step 1 of the ticket)

The ticket estimated "50+". The real surface for `cmd/dev-health-worker`, `-reconciler`, `-scheduler`, and `dev-health-stream-runner` is **85 operator-facing variables**.

| Where | Count | Class | Disposition |
| --- | --- | --- | --- |
| `config.go` provider route switches | 40 | per-deployment | **No flag** — env-only, see below |
| `config.go` credentials/DSNs | 10 | per-deployment, secret | **No flag, by design** — env-only |
| `config.go` River/database | 14 | per-deployment | Purpose-named flags |
| `config.go` operational bridge | 3 (+1 secret) | per-deployment | Purpose-named flags |
| `config.go` process runtime | 7 | per-worker | `-c`, `--worker-group`, `--shutdown-timeout`, `--http-addr`, `--log-level`, `--health-check-timeout`, `--stream-replicas` |
| `config.go` route config paths | 2 | per-deployment | `--github-work-items-*` |
| `config.go` preset | 2 | per-deployment | `--environment` (+ `GO_PROVIDER_ROUTES`, env-only) |
| `tracing.go` `OTEL_*` | 5 | debug/telemetry | **Out of scope** — unchanged, env-only |
| `shell.go` | 1 | per-worker | `--profile` |

**Dead vars: none.** Every name still has a live reader, so the ticket's "kill list" is empty. Reporting that rather than inventing deletions.

**Deliberately out of scope (6 parity shims):** `STATUS_MAPPING_PATH`, `GITHUB_PROJECTS_V2`, `REPO_UUID`, `LINEAR_TRUSTED_SCM_HOSTS`, `OPERATIONAL_ORDERING_CONTRACT`, `GITHUB_LINEAR_LINKBACK_BOTS`. These are Python-parity shims inside provider routes, not deployment configuration — the worker already *rejects* an ambient `STATUS_MAPPING_PATH`.

## Design

**The CLI mirrors the Python Celery worker.** `compose.yml`'s Celery services run `celery … worker -Q default,sync,… --concurrency=N`. The Go worker now takes `-Q/--queues` and `-c/--concurrency` with the same meaning, plus `--loglevel` as an accepted alias. `-q` and `--queue-concurrency` stay as aliases so nothing outside this repo breaks.

**One registry, three consumers.** `internal/platform/config/options.go` declares each setting once (flag, short form, aliases, env fallback, kind, default, usage, secret, service scope). `--help` is rendered from it, the `flag.FlagSet` is registered from it, and error messages are labelled from it. A setting cannot exist on some surfaces and not others — the four-surface wiring problem CHAOS-3942 paid for.

**Precedence via a layered lookup.** Every resolution helper already took a `secrets.LookupEnv`, so layering flag overrides beneath it gave the whole surface flag > env > default without teaching ~80 call sites about flags.

**Provider route switches get no flag, on purpose.** The 40 `WORKER_*_ENABLED` switches stay environment-only. What a worker executes follows from the queues it subscribes to; a parallel 40-switch enablement surface does not scale and is the thing being designed away. They survive because the Python planner reads the identical names through `ProviderUnitRouteSwitches` to decide what to *plan* — a planner emitting units for a route no executor serves is the wedge CHAOS-3990 exists to prevent. *(`provider_unit_route.py` is untouched, so no `governance` markers are required.)*

## The two fleets do not share a queue vocabulary

Both sets are generated from source in `test_go_queue_names_that_exist_in_celery_agree_byte_for_byte`, not hand-authored:

* **Celery** (`workers/config.py task_queues`) declares 23 queues.
* **Go River** (`deploy/go-workers/deployment.json`) serves 10.
* **Shared: 4** — `metrics`, `reports`, `sync`, `webhooks`.
* **Go-only: 6** — `coverage`, `heartbeat`, `investment`, `retention`, `sync_provider`, `workgraph`.
* **Celery-only: 19** — `backfill`, `default`, `external-ingest`, `ingest`, `monitoring`, `scheduler`, and all 13 `sync.<provider>[.class]`.

`-Q` is **forward-compatible with the CHAOS-4027 subpath topology**: it takes an arbitrary queue list, and validation is a charset check plus the runtime's selected-equals-constructed rule — never a restriction on queue-name *shape*. Dotted names like `sync.github` and `sync.github.heavy` already parse today, so when finer-grained River queues land the CLI needs no change. `TestQueueSelectionAcceptsDottedSubpathNames` pins that, so a future tightening into a flat-name pattern cannot break it silently.

These are different transports (Redis lists vs Postgres rows), so `-Q` names **Go River queue names**. Making the binary accept Celery's names would advertise queues the fleet cannot serve: Go startup validation requires the selected queue set to equal the *constructed* handler set, so `-Q backfill` would fail readiness. The test pins the shared names byte-for-byte and pins both divergence lists, so neither runtime can drift silently. **Aligning the two vocabularies is a River queue migration** (deployment.json, four deploy surfaces, autoscaler metric selectors, in-flight jobs, a drain plan) and belongs in its own ticket.

## Behaviour changes worth review attention

1. **Flag > env replaces a "flag conflicts with env" hard error** on `--worker-group`, `--shutdown-timeout`, and `--concurrency`. Required, not incidental: moving configuration into `command:` while host `.env` files still carry those variables would have failed *every* worker at cutover under conflict semantics. The shadowed setting is named in a startup warning instead.
2. **`--queue-concurrency` still works** as a deprecated alias of `-c/--concurrency`, because manifests outside this repository (including the untracked host `dev-health/compose.yml`) still pass it.
3. **`OTEL_*` is untouched.** `tracing.go` and `tracing_test.go` are byte-identical to `main`, including the CHAOS-3993 warn-and-disable on a malformed sample rate.

## Operator migration notes

* **No action is required to keep working.** Every existing environment variable still resolves. Flags win where both are set, and each start logs one warning naming settings that came from the environment.
* **`docker compose config` is now the source of truth** for a worker's configuration. `environment:` on a Go worker service is down to 6 credentials plus `AUTO_RUN_MIGRATIONS` (a Python-image variable, not a worker setting).
* **These ten stay in the environment permanently:** `POSTGRES_URI`, `WORKER_DATABASE_URI`, `COORDINATOR_DATABASE_URI`, `CLICKHOUSE_URI`, `VALKEY_URI`, `SETTINGS_ENCRYPTION_KEY`, `SETTINGS_ENCRYPTION_SALT`, `PAGER_DUTY_CLIENT_ID`, `PAGER_DUTY_SECRET`, `WORKER_OPERATIONAL_BRIDGE_TOKEN`. A DSN or token in `command:` is readable through `ps`, `docker inspect`, and `docker compose config`.
* **Route enablement is unchanged.** `WORKER_*_ENABLED` and `GO_PROVIDER_ROUTES=all` keep working exactly as before.
* **Untracked host files were not modified.** `dev-health/compose.yml` and the production `.env` keep working unchanged via the env fallback and the `--queue-concurrency` alias.

## Acceptance criteria

| Criterion | Evidence |
| --- | --- |
| A new operator configures a worker from `--help` alone | `TestEveryNonSecretSettingIsReachableFromHelp`, `TestHelpListsEveryOptionAndExitsCleanly` |
| A typo'd option fails loudly at startup | `TestUnknownFlagIsRejectedAtStartup` (exit 2, before dependency construction), `TestRoutesFlagIsGone`; `test_deploy_manifests_only_pass_flags_the_binaries_accept` catches a typo at review time |
| Documented env count drops to a handful | `TestHelpDeclaresTheDocumentedEnvironmentHandful`, `test_registry_declares_the_credentials_that_stay_in_the_environment`, `test_compose_surfaces_keep_only_credentials_in_the_environment` |

Verified on the built binary:

```
$ dev-health-worker --queeues=x
argument error: flag provided but not defined: -queeues
run dev-health-worker --help for the full option list   # exit 2

$ DEV_HEALTH_WORKER_GROUP=from-env DEV_HEALTH_LOG_LEVEL=debug dev-health-worker \
    -Q heartbeat -c heartbeat=1 --worker-group=from-flag
{"msg":"configuration supplied through environment variables","settings":"log-level"}
{"msg":"service starting","worker_group":"from-flag", ...}
```

## Testing

* `bash ci/check_go.sh ci` → rc=0
* `bash ci/local_validate.sh` → **GATE PASSED**, `declared=8 executed=8` (`lint_format, lint_check, typecheck, ch_probe, ch_scratch_create, ch_migrate, unit_suite, ch_argmax_proof`) — every stage really ran, no `SKIP_CLICKHOUSE` opt-out
* `go test ./internal/... ./cmd/...` → pass
* `pytest tests/workers tests/tooling tests/docs tests/test_compose_config.py` → 965 passed, 5 skipped
* `ruff format --check` + `ruff check` + `mypy` → clean
* `helm template` renders all 9 Go worker deployments
* The manifest typo guard was mutation-checked: injecting `--http-addrr` into `deploy/kubernetes/go-workers.yaml` fails the test; the file was restored and verified by SHA-256 content digest.

## Review

Reviewed adversarially by Codex against `origin/main...HEAD`. It found **three real defects, all fixed in this branch**. None were dismissed.

**1. P1 — the Kubernetes manifests silently disabled the ConfigMap.** Six settings (`--river-schema`, both database roles, both operational-bridge flags, and `--pagerduty-webhook-transport`) were hard-coded into all nine Deployments while those pods still `envFrom` `dev-health-config`. Because flags now beat env, editing the ConfigMap would have changed nothing for Go workers — this change would have removed the Kubernetes operator's tuning surface while claiming to improve discoverability.

The sharp edge is `PAGERDUTY_WEBHOOK_TRANSPORT`: both runtimes read it, and the contract is that exactly one owns the webhook stream. A ConfigMap edit to `river` would have flipped the Python API while the hard-coded Go argument stayed `celery`, leaving the stream with two owners reconciling and deleting each other's entries — a deploy-time cause with a runtime symptom.

Fixed: those six flags are gone from the manifests. Args now carry only per-deployment settings that were never ConfigMap-backed (`--queues`, `--queue-concurrency`, `--worker-group`, `--shutdown-timeout`, `--profile`, `--http-addr` — all previously inline env on the Deployment, so no tunability is lost). Compose and Swarm keep their flags because there the values come from `${VAR:-default}` interpolation, which still works inside `command:`; every value was verified unchanged. Guarded by `test_kubernetes_args_never_shadow_the_configmap`.

**2. P2 — a blank flag shadowed a non-blank environment value.** `--shutdown-timeout=` with `DEV_HEALTH_SHUTDOWN_TIMEOUT=7260s` resolved to the 30s default and flipped `ShutdownTimeoutExplicit`, changing the drain-budget branch in `cmd/dev-health-worker`. The same regression hit `--worker-group=` (became `worker`) and `--unreclaimable-sweep=` (became `shadow` instead of `active`), so it damaged CHAOS-4005's flag too. On `main`, `durationArgumentOrEnv` trimmed a blank argument and fell through to the environment; `overridesFrom` recorded blank-as-set. Fixed by skipping blank values, restoring the blank-means-unset convention that `envOrDefault`, `durationEnv`, and `boolEnv` all already follow.

**Worth recording: this branch already had a blank-value test, and it could not have caught this.** `TestBlankValuesAreTreatedAsUnsetOnBothSurfaces` asserts that a blank flag resolves to the *default* — with no environment value present. Both "blank is ignored" and "blank overrides with nothing" satisfy that assertion, so it passed while the second was true. The distinguishing case needs a **non-blank environment value behind the blank flag**; without one the test observes an outcome that the mechanism does not uniquely produce. `TestBlankFlagDoesNotShadowTheEnvironment` is that case, and with the fix removed it fails with `shutdown timeout = 30s, want the environment's 7260s`.

**3. P2 — chart-wide `goWorkers.extraArgs` could crash unrelated pods.** Options are scoped per binary, so a global `--unreclaimable-sweep=active` would make the worker, scheduler, and stream-runner exit 2 on an unknown flag. Removed from `values.yaml`, the schema, and the template. Per-group `extraArgs` remains — the only granularity consistent with per-binary option scoping, since an operator scopes a flag to the group that accepts it.

Both new guards were **mutation-checked**: each fails when its defect is reintroduced, and the mutated file was restored and verified by SHA-256 content digest rather than by a build or a `git` check.

Codex explicitly cleared: secret and undeclared override rejection, `envOnlySettings` reading the raw environment, non-blank flag-over-environment precedence, route fallback and the all-routes preset matching `main` across all 40 mappings, shell aliasing, repeatable joining, boolean flags, stream profiles, reconciler sweep reachability, and Compose + Swarm value preservation.

## CHAOS-4005's `--unreclaimable-sweep`, folded in

This branch rebases onto CHAOS-4005 and folds its flag into the registry as a **reconciler-scoped entry** rather than leaving a second flag mechanism alongside this one. Preserved exactly as that ticket shipped them: the flag name, the `off|shadow|active` enum with `ParseSweepMode`'s strict rejection of unknown values (untouched), the `SYNC_UNRECLAIMABLE_SWEEP` fallback, the `shadow` default, and the "Setting active asserts that no Celery consumer serves provider units for this deployment" warning, byte-for-byte.

Only the *resolution path* changed: a private flag>env branch inside `Load` became the shared layered lookup, so this flag gets precedence from the same mechanism as every other setting. CHAOS-4005's own `TestUnreclaimableSweepFlagBeatsEnvironment` is kept — all four cases — adapted to supply the flag the way the shell layer actually supplies it, so *their* pin still guards the behaviour.

Two things became redundant and were removed: `shell.Spec.UnreclaimableSweep bool` and the opt-in line in `cmd/dev-health-reconciler/main.go`. The registry's `Services: ["dev-health-reconciler"]` scope is now the single source for which binary offers the flag. `TestUnreclaimableSweepIsReconcilerScoped` asserts it appears in the reconciler's `--help` with all four preserved fragments **and** is absent from the worker, scheduler, and stream-runner.
